### PR TITLE
enable setup sofaark for sofaboot version after 3.4.7 by add sofaboot ark plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <module>sofa-ark-parent</module>
         <module>sofa-ark-plugin/config-ark-plugin</module>
         <module>sofa-ark-plugin/web-ark-plugin</module>
+        <module>sofa-ark-plugin/sofaboot-ark-plugin</module>
     </modules>
 
     <properties>

--- a/sofa-ark-plugin/sofaboot-ark-plugin/pom.xml
+++ b/sofa-ark-plugin/sofaboot-ark-plugin/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sofa-ark-bom</artifactId>
+        <groupId>com.alipay.sofa</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../sofa-ark-bom</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sofaboot-ark-plugin</artifactId>
+
+    <properties>
+        <sofa.boot.version>3.11.0</sofa.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>runtime-sofa-boot</artifactId>
+            <version>${sofa.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.alipay.sofa</groupId>
+                <artifactId>sofa-ark-plugin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <goals>
+                            <goal>ark-plugin</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <activator>com.alipay.sofa.boot.ark.activator.SOFABootRuntimeActivator</activator>
+                    <!-- 配置导出类、资源 -->
+                    <exported>
+                        <!-- 配置 ark plugin 对外导出的资源 -->
+                        <resources>
+                            <resource>META-INF/spring.*</resource>
+                            <resource>META-INF/services/*</resource>
+                            <resource>META-INF/com/alipay/boot/middleware/service/config/*</resource>
+                            <resource>org/springframework/boot/logging/*</resource>
+                            <resource>*.xsd</resource>
+                            <resource>*/sql-map-2.dtd</resource>
+                            <resource>*/sql-map-config-2.dtd</resource>
+                            <resource>*/mybatis-3-config.dtd</resource>
+                            <resource>*/mybatis-3-mapper.dtd</resource>
+                        </resources>
+                    </exported>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sofa-ark-plugin/sofaboot-ark-plugin/src/main/java/com/alipay/sofa/boot/ark/activator/SOFABootRuntimeActivator.java
+++ b/sofa-ark-plugin/sofaboot-ark-plugin/src/main/java/com/alipay/sofa/boot/ark/activator/SOFABootRuntimeActivator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.ark.activator;
+
+import com.alipay.sofa.ark.spi.model.PluginContext;
+import com.alipay.sofa.ark.spi.service.PluginActivator;
+import com.alipay.sofa.ark.spi.service.event.EventAdminService;
+import com.alipay.sofa.runtime.SofaBizHealthCheckEventHandler;
+import com.alipay.sofa.runtime.SofaBizUninstallEventHandler;
+import com.alipay.sofa.runtime.invoke.DynamicJvmServiceProxyFinder;
+import com.alipay.sofa.runtime.spring.AfterBizStartupEventHandler;
+import com.alipay.sofa.runtime.spring.FinishStartupEventHandler;
+
+/**
+ * @author qilong.zql
+ * @since 2.5.0
+ */
+public class SOFABootRuntimeActivator implements PluginActivator {
+
+    @Override
+    public void start(PluginContext context) {
+        try {
+            registerEventHandler(context);
+            context.publishService(DynamicJvmServiceProxyFinder.class,
+                DynamicJvmServiceProxyFinder.getDynamicJvmServiceProxyFinder());
+        } catch (Throwable t) {
+            throw new RuntimeException("start serverless runtime plugin error", t);
+        }
+    }
+
+    private void registerEventHandler(final PluginContext context) {
+        EventAdminService eventAdminService = context.referenceService(EventAdminService.class)
+            .getService();
+        eventAdminService.register(new SofaBizUninstallEventHandler());
+        eventAdminService.register(new SofaBizHealthCheckEventHandler());
+        eventAdminService.register(new FinishStartupEventHandler());
+        eventAdminService.register(new AfterBizStartupEventHandler());
+    }
+
+    @Override
+    public void stop(PluginContext context) {
+    }
+}

--- a/sofa-ark-plugin/web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/tomcat/ArkTomcatEmbeddedWebappClassLoader.java
+++ b/sofa-ark-plugin/web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/tomcat/ArkTomcatEmbeddedWebappClassLoader.java
@@ -31,6 +31,34 @@ import java.util.Enumeration;
  * ensure that any custom context class loader is always used (as is the case with some
  * executable archives).
  *
+ * There are two case to initialize tomcat for multi biz model:
+ *
+ * 1. When included this Tomcat ClassLoader by
+ * {@link com.alipay.sofa.ark.web.embed.tomcat.ArkTomcatEmbeddedWebappClassLoader},
+ * this will ensure there should always be one tomcat instance with only one port.
+ * In this case, each module use same web port, must define different web context path.
+ *
+ *   --------------
+ *  │ Biz Module A │\
+ *   --------------  \
+ *                    \----→ Tomcat 1: Port 1
+ *   --------------   /
+ *  │ Biz Module B │/
+ *   --------------
+ *
+ * 2. If not included, then each biz module with mvc will create a tomcat,
+ * In this case, each module can define any web context path, but must define different web server port.
+ *
+ *   --------------
+ *  │ Biz Module A │ ----→ Tomcat 1: Port 1
+ *   --------------
+ *
+ *   --------------
+ *  │ Biz Module B │ ----→ Tomcat 2: Port2
+ *   --------------
+ *
+ * Actually, the mostly used in prod env is the first case, so we need to include a web plugin.
+ *
  * @author qilong.zql
  * @author Phillip Webb
  * @since 0.6.0


### PR DESCRIPTION
### Motivation:

From SOFABoot 3.4.7, part of initialization for sofa-ark had been removed out of sofaboot, so the project base on sofaboot 3.4.7 or later can't start up anymore. 
This PR will extract such initialization in to a sofaboot ark plugin.

### Modification:
To setup sofaArk for SOFABoot 3.4.7 or later.

### Result:

Fixes #469 . 
