### PR TITLE
Support jdk 11

### DIFF
--- a/sofa-ark-bom/pom.xml
+++ b/sofa-ark-bom/pom.xml
@@ -18,7 +18,7 @@
         <logback.version>1.1.11</logback.version>
 
         <guice.version>4.0</guice.version>
-        <asm.version>5.0.3</asm.version>
+        <asm.version>7.0</asm.version>
         <commons.io.version>2.5</commons.io.version>
         <commons.lang3.version>3.3.1</commons.lang3.version>
 
@@ -40,7 +40,7 @@
         <system.rules.version>1.16.0</system.rules.version>
 
         <maven.assembly.plugin>2.4</maven.assembly.plugin>
-        <maven.plugin.plugin>3.4</maven.plugin.plugin>
+        <maven.plugin.plugin>3.5</maven.plugin.plugin>
         <surefire.version>2.20</surefire.version>
         <netty.version>4.1.42.Final</netty.version>
         <spring.loader.version>2.5.6</spring.loader.version>

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceImpl.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceImpl.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.ark.container.service.biz;
 
 import com.alipay.sofa.ark.api.ArkConfigs;
 import com.alipay.sofa.ark.common.util.AssertUtils;
+import com.alipay.sofa.ark.common.util.ClassLoaderUtils;
 import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.common.util.StringUtils;
 import com.alipay.sofa.ark.container.model.BizModel;
@@ -129,7 +130,7 @@ public class BizFactoryServiceImpl implements BizFactoryService {
             .setWebContextPath("/").setDenyImportPackages(null).setDenyImportClasses(null)
             .setDenyImportResources(null).setInjectPluginDependencies(new HashSet<>())
             .setInjectExportPackages(null)
-            .setClassPath(((URLClassLoader) masterClassLoader).getURLs())
+            .setClassPath(ClassLoaderUtils.getURLs(masterClassLoader))
             .setClassLoader(masterClassLoader);
         return bizModel;
     }

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/AbstractClasspathClassLoader.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/AbstractClasspathClassLoader.java
@@ -26,7 +26,6 @@ import com.alipay.sofa.ark.loader.jar.Handler;
 import com.alipay.sofa.ark.spi.constant.Constants;
 import com.alipay.sofa.ark.spi.service.classloader.ClassLoaderService;
 import com.google.common.cache.Cache;
-import sun.misc.CompoundEnumeration;
 
 import java.io.IOException;
 import java.net.JarURLConnection;
@@ -35,11 +34,7 @@ import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.jar.JarFile;
 

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/ClassLoaderServiceImpl.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/ClassLoaderServiceImpl.java
@@ -33,7 +33,6 @@ import com.google.inject.Singleton;
 
 import java.io.File;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -278,7 +277,7 @@ public class ClassLoaderServiceImpl implements ClassLoaderService {
         List<URL> jdkUrls = new ArrayList<>();
         try {
             String javaHome = System.getProperty("java.home").replace(File.separator + "jre", "");
-            URL[] urls = ((URLClassLoader) systemClassLoader).getURLs();
+            URL[] urls = ClassLoaderUtils.getURLs(systemClassLoader);
             for (URL url : urls) {
                 if (url.getPath().startsWith(javaHome)) {
                     if (LOGGER.isDebugEnabled()) {

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/CompoundEnumeration.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/CompoundEnumeration.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.container.service.classloader;
+
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+
+/*
+ * A utility class that will enumerate over an array of enumerations.
+ */
+public final class CompoundEnumeration<E> implements Enumeration<E> {
+    private final Enumeration<E>[] enums;
+    private int                    index;
+
+    public CompoundEnumeration(Enumeration<E>[] enums) {
+        this.enums = enums;
+    }
+
+    private boolean next() {
+        while (index < enums.length) {
+            if (enums[index] != null && enums[index].hasMoreElements()) {
+                return true;
+            }
+            index++;
+        }
+        return false;
+    }
+
+    public boolean hasMoreElements() {
+        return next();
+    }
+
+    public E nextElement() {
+        if (!next()) {
+            throw new NoSuchElementException();
+        }
+        return enums[index].nextElement();
+    }
+}

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/plugin/PluginFactoryServiceImpl.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/plugin/PluginFactoryServiceImpl.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.ark.container.service.plugin;
 
 import com.alipay.sofa.ark.api.ArkConfigs;
 import com.alipay.sofa.ark.common.util.AssertUtils;
+import com.alipay.sofa.ark.common.util.ClassLoaderUtils;
 import com.alipay.sofa.ark.common.util.StringUtils;
 import com.alipay.sofa.ark.container.model.PluginContextImpl;
 import com.alipay.sofa.ark.container.model.PluginModel;
@@ -187,7 +188,7 @@ public class PluginFactoryServiceImpl implements PluginFactoryService {
             .setVersion(manifestMainAttributes.getValue(PLUGIN_VERSION_ATTRIBUTE))
             .setPriority(manifestMainAttributes.getValue(PRIORITY_ATTRIBUTE))
             .setPluginActivator(manifestMainAttributes.getValue(ACTIVATOR_ATTRIBUTE))
-            .setClassPath(((URLClassLoader) masterClassLoader).getURLs())
+            .setClassPath(ClassLoaderUtils.getURLs(masterClassLoader))
             .setPluginUrl(pluginArchive.getUrl())
             .setExportClasses(
                 enableExportClass ? manifestMainAttributes.getValue(EXPORT_CLASSES_ATTRIBUTE)

--- a/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/classloader/hook/AbstractClassLoaderHook.java
+++ b/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/classloader/hook/AbstractClassLoaderHook.java
@@ -18,7 +18,8 @@ package com.alipay.sofa.ark.container.service.classloader.hook;
 
 import com.alipay.sofa.ark.spi.service.classloader.ClassLoaderHook;
 import com.alipay.sofa.ark.spi.service.classloader.ClassLoaderService;
-import sun.misc.CompoundEnumeration;
+import com.alipay.sofa.ark.container.service.classloader.CompoundEnumeration;
+//import sun.misc.CompoundEnumeration;
 
 import java.io.IOException;
 import java.net.URL;

--- a/sofa-ark-parent/support/ark-plugin-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
+++ b/sofa-ark-parent/support/ark-plugin-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
@@ -266,7 +266,7 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
             <type>jar</type>
-            <version>5.0.3</version>
+            <version>7.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/sofa-ark-parent/support/ark-support-starter/src/main/java/com/alipay/sofa/ark/support/startup/EmbedSofaArkBootstrap.java
+++ b/sofa-ark-parent/support/ark-support-starter/src/main/java/com/alipay/sofa/ark/support/startup/EmbedSofaArkBootstrap.java
@@ -18,13 +18,13 @@ package com.alipay.sofa.ark.support.startup;
 
 import com.alipay.sofa.ark.api.ArkConfigs;
 import com.alipay.sofa.ark.bootstrap.ClasspathLauncher;
+import com.alipay.sofa.ark.common.util.ClassLoaderUtils;
 import com.alipay.sofa.ark.loader.EmbedClassPathArchive;
 import com.alipay.sofa.ark.spi.argument.CommandArgument;
 import com.alipay.sofa.ark.support.common.DelegateToMasterBizClassLoaderHook;
 import org.springframework.core.env.Environment;
 
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.alipay.sofa.ark.spi.constant.Constants;
@@ -79,6 +79,7 @@ public class EmbedSofaArkBootstrap {
 
     private static URL[] getURLClassPath() {
         ClassLoader classLoader = EmbedSofaArkBootstrap.class.getClassLoader();
-        return ((URLClassLoader) classLoader).getURLs();
+        //        return ((URLClassLoader) classLoader).getURLs();
+        return ClassLoaderUtils.getURLs(classLoader);
     }
 }

--- a/sofa-ark-parent/support/ark-support-starter/src/main/java/com/alipay/sofa/ark/support/startup/SofaArkBootstrap.java
+++ b/sofa-ark-parent/support/ark-support-starter/src/main/java/com/alipay/sofa/ark/support/startup/SofaArkBootstrap.java
@@ -19,6 +19,7 @@ package com.alipay.sofa.ark.support.startup;
 import com.alipay.sofa.ark.bootstrap.ClasspathLauncher;
 import com.alipay.sofa.ark.bootstrap.ClasspathLauncher.ClassPathArchive;
 import com.alipay.sofa.ark.common.util.AssertUtils;
+import com.alipay.sofa.ark.common.util.ClassLoaderUtils;
 import com.alipay.sofa.ark.spi.argument.CommandArgument;
 import com.alipay.sofa.ark.support.thread.IsolatedThreadGroup;
 import com.alipay.sofa.ark.support.thread.LaunchRunner;
@@ -88,7 +89,8 @@ public class SofaArkBootstrap {
 
     private static URL[] getURLClassPath() {
         ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-        return ((URLClassLoader) classLoader).getURLs();
+        //        return ((URLClassLoader) classLoader).getURLs();
+        return ClassLoaderUtils.getURLs(classLoader);
     }
 
     private static boolean isSofaArkStarted() {


### PR DESCRIPTION
### Motivation:
To support jdk11.

### Modification:
- To get `ucp` of `AppClassloader`: add `ClassLoaderUtils.getURLs` and update the use of `ucp` in sofa-ark
- To fix `CompoundEnumeration` not found: add `CompoundEnumeration` and update references in `AbstractClassLoaderHook` and `AbstractClasspathClassLoader`
- To package biz: bump `maven.plugin.plugin` to 3.5 and `asm` to 7.0

### Result:

Fixes  #<495> and #<492>. 

