### PR TITLE
修复插件declared-libraries的解析赋值

### DIFF
--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
@@ -333,10 +333,12 @@ public class RepackageMojo extends TreeMojo {
     }
 
     private void parseArtifactItems(DependencyNode rootNode, Set<ArtifactItem> result) {
-        if (rootNode != null && CollectionUtils.isNotEmpty(rootNode.getChildren())) {
-            for (DependencyNode node : rootNode.getChildren()) {
-                result.add(ArtifactItem.parseArtifactItem(rootNode.getArtifact()));
-                parseArtifactItems(node, result);
+        if (rootNode != null) {
+            result.add(ArtifactItem.parseArtifactItem(rootNode.getArtifact()));
+            if (CollectionUtils.isNotEmpty(rootNode.getChildren())) {
+                for (DependencyNode node : rootNode.getChildren()) {
+                    parseArtifactItems(node, result);
+                }
             }
         }
     }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
@@ -68,7 +68,6 @@ public class RepackageMojoTest {
                           && ((LinkedHashSet) excludesResult).contains("tracer-core:3.0.11"));
     }
 
-
     /**
      * 测试依赖解析
      *
@@ -77,8 +76,8 @@ public class RepackageMojoTest {
      * @throws IllegalAccessException
      */
     @Test
-    public void testParseArtifactItems()
-            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void testParseArtifactItems() throws NoSuchMethodException, InvocationTargetException,
+                                        IllegalAccessException {
 
         /**
          *  构建依赖图
@@ -97,27 +96,29 @@ public class RepackageMojoTest {
          *
          */
         DefaultDependencyNode bizNode = buildDependencyNode(null, "com.alipay.sofa", "biz", "1.0.0");
-        DefaultDependencyNode bizChild1 = buildDependencyNode(bizNode, "com.alipay.sofa", "biz-child1", "1.0.0");
-        DefaultDependencyNode bizChild2 = buildDependencyNode(bizNode, "com.alipay.sofa", "biz-child2", "1.0.0");
+        DefaultDependencyNode bizChild1 = buildDependencyNode(bizNode, "com.alipay.sofa",
+            "biz-child1", "1.0.0");
+        DefaultDependencyNode bizChild2 = buildDependencyNode(bizNode, "com.alipay.sofa",
+            "biz-child2", "1.0.0");
         buildDependencyNode(bizChild1, "com.alipay.sofa", "biz-child1-child1", "1.0.0");
         buildDependencyNode(bizChild1, "com.alipay.sofa", "biz-child1-child2", "1.0.0");
         buildDependencyNode(bizChild2, "com.alipay.sofa", "biz-child2-child1", "1.0.0");
         buildDependencyNode(bizChild2, "com.alipay.sofa", "biz-child2-child2", "1.0.0");
 
         RepackageMojo repackageMojo = new RepackageMojo();
-        Method parseArtifactItems = repackageMojo.getClass().getDeclaredMethod("parseArtifactItems",
-                DependencyNode.class, Set.class);
+        Method parseArtifactItems = repackageMojo.getClass().getDeclaredMethod(
+            "parseArtifactItems", DependencyNode.class, Set.class);
         parseArtifactItems.setAccessible(true);
         Set<ArtifactItem> artifactItems = new HashSet<>();
         parseArtifactItems.invoke(repackageMojo, bizNode, artifactItems);
         Assert.assertTrue(artifactItems.size() == 7);
     }
 
-    private DefaultDependencyNode buildDependencyNode(DefaultDependencyNode parent, String groupId, String artifactId,
-                                                      String version) {
+    private DefaultDependencyNode buildDependencyNode(DefaultDependencyNode parent, String groupId,
+                                                      String artifactId, String version) {
         DefaultDependencyNode dependencyNode = new DefaultDependencyNode(parent,
-                new DefaultArtifact(groupId, artifactId, version, "provided", "jar", "biz-jar", null), null, null,
-                null);
+            new DefaultArtifact(groupId, artifactId, version, "provided", "jar", "biz-jar", null),
+            null, null, null);
         if (parent != null) {
             if (CollectionUtils.isEmpty(parent.getChildren())) {
                 parent.setChildren(Lists.newArrayList());

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
@@ -16,6 +16,10 @@
  */
 package com.alipay.sofa.ark.boot.mojo;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.internal.DefaultDependencyNode;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,7 +27,12 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Set;
+
+import com.alipay.sofa.ark.tools.ArtifactItem;
+import com.google.common.collect.Lists;
 
 /**
  * @author guolei.sgl (guolei.sgl@antfin.com) 2020/12/16 2:25 下午
@@ -57,5 +66,64 @@ public class RepackageMojoTest {
                           && excludeArtifactIdsResult instanceof LinkedHashSet);
         Assert.assertTrue(((LinkedHashSet) excludesResult).contains("tracer-core:3.0.10")
                           && ((LinkedHashSet) excludesResult).contains("tracer-core:3.0.11"));
+    }
+
+
+    /**
+     * 测试依赖解析
+     *
+     * @throws NoSuchMethodException
+     * @throws InvocationTargetException
+     * @throws IllegalAccessException
+     */
+    @Test
+    public void testParseArtifactItems()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        /**
+         *  构建依赖图
+         *
+         *                   biz-child1-child1
+         *                 /
+         *        biz-child1
+         *       /         \
+         *     /            biz-child1-child2
+         *  biz
+         *     \            biz-child2-child1
+         *      \          /
+         *      biz-child1
+         *                 \
+         *                  biz-child2-child1
+         *
+         */
+        DefaultDependencyNode bizNode = buildDependencyNode(null, "com.alipay.sofa", "biz", "1.0.0");
+        DefaultDependencyNode bizChild1 = buildDependencyNode(bizNode, "com.alipay.sofa", "biz-child1", "1.0.0");
+        DefaultDependencyNode bizChild2 = buildDependencyNode(bizNode, "com.alipay.sofa", "biz-child2", "1.0.0");
+        buildDependencyNode(bizChild1, "com.alipay.sofa", "biz-child1-child1", "1.0.0");
+        buildDependencyNode(bizChild1, "com.alipay.sofa", "biz-child1-child2", "1.0.0");
+        buildDependencyNode(bizChild2, "com.alipay.sofa", "biz-child2-child1", "1.0.0");
+        buildDependencyNode(bizChild2, "com.alipay.sofa", "biz-child2-child2", "1.0.0");
+
+        RepackageMojo repackageMojo = new RepackageMojo();
+        Method parseArtifactItems = repackageMojo.getClass().getDeclaredMethod("parseArtifactItems",
+                DependencyNode.class, Set.class);
+        parseArtifactItems.setAccessible(true);
+        Set<ArtifactItem> artifactItems = new HashSet<>();
+        parseArtifactItems.invoke(repackageMojo, bizNode, artifactItems);
+        Assert.assertTrue(artifactItems.size() == 7);
+    }
+
+    private DefaultDependencyNode buildDependencyNode(DefaultDependencyNode parent, String groupId, String artifactId,
+                                                      String version) {
+        DefaultDependencyNode dependencyNode = new DefaultDependencyNode(parent,
+                new DefaultArtifact(groupId, artifactId, version, "provided", "jar", "biz-jar", null), null, null,
+                null);
+        if (parent != null) {
+            if (CollectionUtils.isEmpty(parent.getChildren())) {
+                parent.setChildren(Lists.newArrayList());
+            }
+            parent.getChildren().add(dependencyNode);
+        }
+        return dependencyNode;
     }
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
@@ -91,7 +91,7 @@ public class RepackageMojoTest {
          *  biz
          *     \            biz-child2-child1
          *      \          /
-         *      biz-child1
+         *      biz-child2
          *                 \
          *                  biz-child2-child1
          *


### PR DESCRIPTION
### Motivation:

基于2.1.0静态部署，ark-biz有传递依赖时启动会报错(类找不到错误)，根据源码点进去看是因为bizClassLoader未加载到到类，最终发现是declared-libraries变量赋值有问题，

### Steps to reproduce
1. ark-biz有依赖
 <dependency>
            <groupId>org.springframework.boot</groupId>
            <artifactId>spring-boot-starter-web</artifactId>
            <scope>provided</scope>
      </dependency>
2. 通过打包命令，不会把tomcat相关jar写到declared-libraries变量中

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #606 

If there is no issue then describe the changes introduced by this PR.
