### PR TITLE
DeclaredMode 优化，多bundle使用mvn tree扫描依赖，资源扫描到模块和基座时使用模块的

### DIFF
--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
@@ -50,7 +50,7 @@ public class JarUtils {
 
     private static final Map<String, Optional<String>> artifactIdCacheMap               = new ConcurrentHashMap<>();
 
-    public static String getArtifactIdFromLocalClassPath(String fileClassPath) throws IOException {
+    public static String getArtifactIdFromLocalClassPath(String fileClassPath) {
         // file:/Users/youji.zzl/Documents/workspace/iexpprodbase/app/bootstrap/target/classes/spring/
         String libraryFile = fileClassPath.replace("file:", "");
         // 1. search pom.properties
@@ -73,6 +73,8 @@ public class JarUtils {
             Properties properties = new Properties();
             properties.load(inputStream);
             return properties.getProperty(JAR_ARTIFACT_ID);
+        } catch (IOException e) {
+            return null;
         }
     }
 

--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
@@ -123,7 +123,8 @@ public class JarUtils {
                 }
             }
         } catch (IOException e) {
-            throw new RuntimeException("Failed to parse artifact id from jar.", e);
+            throw new RuntimeException(String.format("Failed to parse artifact id from jar %s.",
+                jarLocation), e);
         }
     }
 

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
@@ -480,13 +480,7 @@ public class BizModel implements Biz {
                 return true;
             }
         } else {
-            try {
-                artifactId = getArtifactIdFromLocalClassPath(jarFilePath);
-            } catch (IOException e) {
-                LOGGER.error(String.format("Failed to get artifact from %s: %s", jarFilePath,
-                    e.getMessage()));
-                return false;
-            }
+            artifactId = getArtifactIdFromLocalClassPath(jarFilePath);
             // for not in jar, then default not delegate.
             if (artifactId == null) {
                 LOGGER.info(String.format(

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
@@ -497,7 +497,8 @@ public class BizModel implements Biz {
 
         // some ark related lib which each ark module needed should set declared as default
         if (StringUtils.startWithToLowerCase(artifactId, "sofa-ark-")
-            || artifactId.contains("arklet-alipay") || artifactId.contains("-arklet-")) {
+            || artifactId.equals("arklet-alipay-sofa-boot-starter")
+            || artifactId.equals("sofa-boot-alipay-arklet")) {
             return true;
         }
 

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/AbstractClasspathClassLoader.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/classloader/AbstractClasspathClassLoader.java
@@ -324,7 +324,7 @@ public abstract class AbstractClasspathClassLoader extends URLClassLoader {
             }
             while (e.hasMoreElements()) {
                 URL resourceUrl = e.nextElement();
-                String filePath = resourceUrl.getFile();
+                String filePath = resourceUrl.getFile().replace("file:", "");
 
                 String artifactId;
                 if (filePath.contains(".jar")) {

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/MavenUtils.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/MavenUtils.java
@@ -16,9 +16,27 @@
  */
 package com.alipay.sofa.ark.boot.mojo;
 
+import com.alipay.sofa.ark.common.util.StringUtils;
+import com.alipay.sofa.ark.tools.ArtifactItem;
 import org.apache.maven.project.MavenProject;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
 public class MavenUtils {
+    public static boolean isRootProject(MavenProject project) {
+        if (project == null) {
+            return true;
+        }
+
+        if (project.hasParent() && project.getParent().getBasedir() != null) {
+            return false;
+        }
+        return true;
+    }
+
     public static MavenProject getRootProject(MavenProject project) {
         if (project == null) {
             return null;
@@ -28,5 +46,61 @@ public class MavenUtils {
             parent = parent.getParent();
         }
         return parent;
+    }
+
+    /**
+     * @param depTreeContent
+     * @return
+     */
+    public static Set<ArtifactItem> convert(String depTreeContent) {
+        Set<ArtifactItem> artifactItems = new HashSet<>();
+        String[] contents = depTreeContent.split("\n");
+
+        for (String content : contents) {
+            ArtifactItem artifactItem = getArtifactItem(content);
+            if (artifactItem != null && !"test".equals(artifactItem.getScope())) {
+                artifactItems.add(artifactItem);
+            }
+        }
+
+        return artifactItems;
+    }
+
+    private static ArtifactItem getArtifactItem(String lineContent) {
+        if (StringUtils.isEmpty(lineContent)) {
+            return null;
+        }
+        String[] contentInfos = lineContent.split(" ");
+        if (contentInfos.length == 0) {
+            return null;
+        }
+        Optional<String> artifactStrOp = Arrays.stream(contentInfos).filter(c -> c.contains(":")).findFirst();
+        if (!artifactStrOp.isPresent()) {
+            return null;
+        }
+        String[] artifactInfos = artifactStrOp.get().split(":");
+
+        ArtifactItem artifactItem = new ArtifactItem();
+        if (artifactInfos.length == 5) {
+            // like "com.alipay.sofa:healthcheck-sofa-boot-starter:jar:3.11.1:provided"
+
+            artifactItem.setGroupId(artifactInfos[0]);
+            artifactItem.setArtifactId(artifactInfos[1]);
+            artifactItem.setType(artifactInfos[2]);
+            artifactItem.setVersion(artifactInfos[3]);
+            artifactItem.setScope(artifactInfos[4]);
+        } else if (artifactInfos.length == 6) {
+            // like "io.sofastack:dynamic-stock-mng:jar:ark-biz:1.0.0:compile"
+
+            artifactItem.setGroupId(artifactInfos[0]);
+            artifactItem.setArtifactId(artifactInfos[1]);
+            artifactItem.setType(artifactInfos[2]);
+            artifactItem.setClassifier(artifactInfos[3]);
+            artifactItem.setVersion(artifactInfos[4]);
+            artifactItem.setScope(artifactInfos[5]);
+        } else {
+            return null;
+        }
+        return artifactItem;
     }
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
@@ -22,6 +22,7 @@ import com.alipay.sofa.ark.tools.ArtifactItem;
 import com.alipay.sofa.ark.tools.Libraries;
 import com.alipay.sofa.ark.tools.Repackager;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
@@ -42,17 +43,28 @@ import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.alipay.sofa.ark.spi.constant.Constants.ARK_CONF_BASE_DIR;
 import static com.alipay.sofa.ark.spi.constant.Constants.EXTENSION_EXCLUDES;
@@ -313,7 +325,12 @@ public class RepackageMojo extends TreeMojo {
             getLog());
         try {
             if (repackager.isDeclaredMode()) {
-                Set<ArtifactItem> artifactItems = getAllArtifact();
+                Set<ArtifactItem> artifactItems = new HashSet<>();
+                if (MavenUtils.isRootProject(this.mavenProject)) {
+                    getAllArtifact();
+                } else {
+                    getAllArtifactByMavenTree();
+                }
                 repackager.prepareDeclaredLibraries(artifactItems);
             }
             MavenProject rootProject = MavenUtils.getRootProject(this.mavenProject);
@@ -352,6 +369,44 @@ public class RepackageMojo extends TreeMojo {
         Set<ArtifactItem> results = new HashSet<>();
         parseArtifactItems(dependencyNode, results);
         return results;
+    }
+
+    private Set<ArtifactItem> getAllArtifactByMavenTree() throws MojoExecutionException {
+        File baseDir = MavenUtils.getRootProject(this.mavenProject).getBasedir();
+        getLog().info("root project path: " + baseDir.getAbsolutePath());
+
+        // dependency:tree
+        String outputPath = baseDir.getAbsolutePath() + "/deps.log." + System.currentTimeMillis();
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setPomFile(new File(baseDir.getAbsolutePath() + "/pom.xml"));
+
+        List<String> goals = Stream.of("dependency:tree", "-DappendOutput=true",
+            "-DoutputFile=" + outputPath).collect(Collectors.toList());
+
+        Properties userProperties = projectBuildingRequest.getUserProperties();
+        if (userProperties.containsKey("maven.repo.local")) {
+            goals.add("-Dmaven.repo.local=" + userProperties.getProperty("maven.repo.local"));
+        }
+        request.setGoals(goals);
+        Invoker invoker = new DefaultInvoker();
+        try {
+            InvocationResult result = invoker.execute(request);
+            if (result.getExitCode() != 0) {
+                throw new MojoExecutionException("execute dependency:tree failed",
+                    result.getExecutionException());
+            }
+
+            String depTreeStr = FileUtils.readFileToString(FileUtils.getFile(outputPath),
+                Charset.defaultCharset());
+            return MavenUtils.convert(depTreeStr);
+        } catch (MavenInvocationException | IOException e) {
+            throw new MojoExecutionException("execute dependency:tree failed", e);
+        } finally {
+            File outputFile = new File(outputPath);
+            if (outputFile.exists()) {
+                outputFile.delete();
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
@@ -334,11 +334,10 @@ public class RepackageMojo extends TreeMojo {
 
     private void parseArtifactItems(DependencyNode rootNode, Set<ArtifactItem> result) {
         if (rootNode != null) {
-            if (StringUtils.equalsIgnoreCase(rootNode.getArtifact().getScope(), "test")) {
-                return;
+            if (!StringUtils.equalsIgnoreCase(rootNode.getArtifact().getScope(), "test")) {
+                result.add(ArtifactItem.parseArtifactItem(rootNode.getArtifact()));
             }
 
-            result.add(ArtifactItem.parseArtifactItem(rootNode.getArtifact()));
             if (CollectionUtils.isNotEmpty(rootNode.getChildren())) {
                 for (DependencyNode node : rootNode.getChildren()) {
                     parseArtifactItems(node, result);


### PR DESCRIPTION
### Motivation:
DeclaredMode 当前还处于 alphabet 版本，进一步完善。


### Modification:

1. 对于多bundle的工程使用 mvn dependency:tree 方式获取模块声明的依赖，避免模块里设置依赖 scope 为 provided 后依赖传递机制导致的部分依赖无法扫描到的问题
2. 委托资源给基座时，如果查找到多个依赖但不同版本时，也去重到只保留模块自身的。

### Result:

修复 #610 
