### PR TITLE
修复因文件路径不支持跨平台导致的资源加载失败问题 （#610）

### DIFF
--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
@@ -99,7 +99,7 @@ public class JarUtils {
             }
         }
 
-        try (InputStream inputStream = Files.newInputStream(Paths.get(pomPropertiesPath))) {
+        try (InputStream inputStream = Files.newInputStream(new File(pomPropertiesPath).toPath())) {
             Properties properties = new Properties();
             properties.load(inputStream);
             return properties.getProperty(JAR_ARTIFACT_ID);

--- a/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/test/jar/JarUtilsTest.java
+++ b/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/test/jar/JarUtilsTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 
@@ -44,14 +46,14 @@ public class JarUtilsTest {
     }
 
     @Test
-    public void getArtifactIdFromClassPath() throws IOException {
+    public void getArtifactIdFromClassPath() throws IOException, URISyntaxException {
         URL clazzURL = this.getClass().getClassLoader()
             .getResource("com/alipay/sofa/ark/loader/jar/JarUtils.class");
 
         String artifactId = JarUtils.parseArtifactId(clazzURL.getPath());
         Assert.assertEquals("sofa-ark-archive", artifactId);
 
-        String classPathRoot = this.getClass().getClassLoader().getResource("").getPath();
+        URI classPathRoot = this.getClass().getClassLoader().getResource("").toURI();
         String classPath = Paths.get(classPathRoot).getParent().toFile().getAbsolutePath();
         String artifactId1 = JarUtils.parseArtifactId(classPath);
         Assert.assertNotNull(artifactId1);


### PR DESCRIPTION
### Motivation:

```java
url.getFile().replace("file:", "")
```

因上述处理URL的代码不能使得文件路径支持跨平台，导致资源扫描和加载失败。


### Modification:

故增加了一个函数来处理URL专路径的需求：

```java
    public static String getPath(URL url) {
        try {
            return Paths.get(url.toURI()).toString();
        } catch (Exception e) {
            return url.getFile().replace("file:", "");
        }
    }
```

### Result:

#610 
