### PR TITLE
feat:Provide a plugin to solve the problem of recycling static variables of module in historical versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <module>sofa-ark-parent</module>
         <module>sofa-ark-plugin/config-ark-plugin</module>
         <module>sofa-ark-plugin/web-ark-plugin</module>
+        <module>sofa-ark-plugin/clean-ark-plugin</module>
     </modules>
 
     <properties>

--- a/sofa-ark-bom/pom.xml
+++ b/sofa-ark-bom/pom.xml
@@ -181,6 +181,12 @@
                 <artifactId>web-ark-plugin</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.alipay.sofa</groupId>
+                <artifactId>clean-ark-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!--third party libraries-->
             <dependency>
                 <groupId>com.google.inject</groupId>

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/pom.xml
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/pom.xml
@@ -126,6 +126,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-loader</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>clean-ark-plugin</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/ArkAutoConfiguration.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/ArkAutoConfiguration.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.ark.springboot;
 
+import com.alipay.sofa.ark.clean.HisBizStaticFieldCleaner;
 import com.alipay.sofa.ark.springboot.condition.ConditionalOnArkEnabled;
 import com.alipay.sofa.ark.springboot.processor.ArkEventHandlerProcessor;
 import com.alipay.sofa.ark.springboot.processor.ArkServiceInjectProcessor;
@@ -65,4 +66,9 @@ public class ArkAutoConfiguration {
         }
 
     }
+    @Bean
+    public static HisBizStaticFieldCleaner hisBizStaticFieldCleaner() {
+        return new HisBizStaticFieldCleaner();
+    }
+
 }

--- a/sofa-ark-plugin/clean-ark-plugin/pom.xml
+++ b/sofa-ark-plugin/clean-ark-plugin/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alipay.sofa</groupId>
+        <artifactId>sofa-ark</artifactId>
+        <version>2.1.3</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>clean-ark-plugin</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-common</artifactId>
+            <type>jar</type>
+            <version>2.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-api</artifactId>
+            <version>2.1.3</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
+++ b/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
@@ -38,7 +38,8 @@ import java.util.List;
 public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizStopEvent> {
     private final static ArkLogger LOGGER = ArkLoggerFactory.getLogger(HisBizStaticFieldCleaner.class);
 
-    @Override public void handleEvent(BeforeBizStopEvent beforeBizStopEvent) {
+    @Override
+    public void handleEvent(BeforeBizStopEvent beforeBizStopEvent) {
         Biz biz = beforeBizStopEvent.getSource();
 
         try {
@@ -57,9 +58,13 @@ public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizStopEvent
             try {
                 Field[] fields = clazz.getDeclaredFields();
                 for (Field field : fields) {
-                    if (Modifier.isStatic(field.getModifiers())) {
-                        field.setAccessible(true);
-                        field.set(null, null);
+                    try {
+                        if (!Modifier.isFinal(field.getModifiers()) && Modifier.isStatic(field.getModifiers())) {
+                            field.setAccessible(true);
+                            field.set(null, null);
+                        }
+                    } catch (Exception e) {
+                        LOGGER.error("Clean static fields meet exception.errMsg = {}" + e.getMessage());
                     }
                 }
                 clazz = null;

--- a/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
+++ b/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
@@ -19,7 +19,7 @@ package com.alipay.sofa.ark.clean;
 import com.alipay.sofa.ark.api.ArkClient;
 import com.alipay.sofa.ark.common.log.ArkLogger;
 import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
-import com.alipay.sofa.ark.spi.event.biz.AfterBizStopEvent;
+import com.alipay.sofa.ark.spi.event.biz.BeforeBizStopEvent;
 import com.alipay.sofa.ark.spi.model.Biz;
 import com.alipay.sofa.ark.spi.service.PriorityOrdered;
 import com.alipay.sofa.ark.spi.service.event.EventHandler;
@@ -35,11 +35,11 @@ import java.util.List;
  * @author firedemo1
  */
 @Component
-public class HisBizStaticFieldCleaner implements EventHandler<AfterBizStopEvent> {
+public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizStopEvent> {
     private final static ArkLogger LOGGER = ArkLoggerFactory.getLogger(HisBizStaticFieldCleaner.class);
 
-    @Override public void handleEvent(AfterBizStopEvent afterBizStopEvent) {
-        Biz biz = afterBizStopEvent.getSource();
+    @Override public void handleEvent(BeforeBizStopEvent beforeBizStopEvent) {
+        Biz biz = beforeBizStopEvent.getSource();
 
         try {
             if (biz != null && biz != ArkClient.getMasterBiz()) {

--- a/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
+++ b/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
@@ -19,11 +19,10 @@ package com.alipay.sofa.ark.clean;
 import com.alipay.sofa.ark.api.ArkClient;
 import com.alipay.sofa.ark.common.log.ArkLogger;
 import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
-import com.alipay.sofa.ark.spi.event.biz.BeforeBizStopEvent;
+import com.alipay.sofa.ark.spi.event.biz.BeforeBizRecycleEvent;
 import com.alipay.sofa.ark.spi.model.Biz;
 import com.alipay.sofa.ark.spi.service.PriorityOrdered;
 import com.alipay.sofa.ark.spi.service.event.EventHandler;
-import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -34,12 +33,11 @@ import java.util.List;
 /**
  * @author firedemo1
  */
-@Component
-public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizStopEvent> {
+public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizRecycleEvent> {
     private final static ArkLogger LOGGER = ArkLoggerFactory.getLogger(HisBizStaticFieldCleaner.class);
 
     @Override
-    public void handleEvent(BeforeBizStopEvent beforeBizStopEvent) {
+    public void handleEvent(BeforeBizRecycleEvent beforeBizStopEvent) {
         Biz biz = beforeBizStopEvent.getSource();
 
         try {
@@ -101,7 +99,8 @@ public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizStopEvent
         return false;
     }
 
-    @Override public int getPriority() {
+    @Override
+    public int getPriority() {
         return PriorityOrdered.HIGHEST_PRECEDENCE;
     }
 }

--- a/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
+++ b/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.clean;
+
+import com.alipay.sofa.ark.api.ArkClient;
+import com.alipay.sofa.ark.common.log.ArkLogger;
+import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
+import com.alipay.sofa.ark.spi.event.biz.AfterBizStopEvent;
+import com.alipay.sofa.ark.spi.model.Biz;
+import com.alipay.sofa.ark.spi.service.PriorityOrdered;
+import com.alipay.sofa.ark.spi.service.event.EventHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author firedemo1
+ */
+@Component
+public class HisBizStaticFieldCleaner implements EventHandler<AfterBizStopEvent> {
+    private final static ArkLogger LOGGER = ArkLoggerFactory.getLogger(HisBizStaticFieldCleaner.class);
+
+    @Override public void handleEvent(AfterBizStopEvent afterBizStopEvent) {
+        Biz biz = afterBizStopEvent.getSource();
+
+        try {
+            if (biz != null && biz != ArkClient.getMasterBiz()) {
+                List<Class<?>> list = findClassesWithStaticFields(biz.getBizClassLoader(), biz.getClassPath()[0].getPath());
+
+                cleanFieldsAndClazz(list);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Clean biz static fields meet exception.errMsg = {}" + e.getMessage());
+        }
+    }
+
+    private void cleanFieldsAndClazz(List<Class<?>> list) {
+        for (Class<?> clazz : list) {
+            try {
+                Field[] fields = clazz.getDeclaredFields();
+                for (Field field : fields) {
+                    if (Modifier.isStatic(field.getModifiers())) {
+                        field.setAccessible(true);
+                        field.set(null, null);
+                    }
+                }
+                clazz = null;
+            } catch (Exception e) {
+                LOGGER.error("Clean static fields meet exception.errMsg = {}" + e.getMessage());
+            }
+        }
+    }
+
+    public List<Class<?>> findClassesWithStaticFields(ClassLoader bizClassLoader, String classPath) {
+        List<Class<?>> classes = new ArrayList<>();
+        File classDir = new File(classPath);
+        File[] classFiles = classDir.listFiles(file -> file.getName().endsWith(".class"));
+        for (File file : classFiles) {
+            String className = file.getName().substring(0, file.getName().lastIndexOf('.'));
+            try {
+                Class<?> cls = bizClassLoader.loadClass(className);
+                if (hasStaticFields(cls)) {
+                    classes.add(cls);
+                }
+            } catch (ClassNotFoundException e) {
+                LOGGER.error("Find classes with static fields meet exception.errMsg = {}" + e.getMessage());
+            }
+        }
+        return classes;
+    }
+
+    private boolean hasStaticFields(Class<?> cls) {
+        for (java.lang.reflect.Field field : cls.getDeclaredFields()) {
+            if (java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override public int getPriority() {
+        return PriorityOrdered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
+++ b/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
@@ -75,7 +75,8 @@ public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizRecycleEv
     public List<Class<?>> findClassesWithStaticFields(ClassLoader bizClassLoader, String classPath) {
         List<Class<?>> classes = new ArrayList<>();
         File classDir = new File(classPath);
-        File[] classFiles = classDir.listFiles(file -> file.getName().endsWith(".class"));
+        File[] classFiles = collectClassFiles(classDir);
+
         for (File file : classFiles) {
             String className = file.getName().substring(0, file.getName().lastIndexOf('.'));
             try {
@@ -88,6 +89,24 @@ public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizRecycleEv
             }
         }
         return classes;
+    }
+    private static File[] collectClassFiles(File classDir) {
+        List<File> fileList = new ArrayList<>();
+        collectClassFiles(classDir, fileList);
+        return fileList.toArray(new File[0]);
+    }
+
+    private static void collectClassFiles(File classDir, List<File> fileList) {
+        File[] files = classDir.listFiles();
+        for (File file : files) {
+            if (file.isFile() && file.getName().endsWith(".class")) {
+                // 处理以".class"结尾的文件
+                fileList.add(file);
+            } else if (file.isDirectory()) {
+                // 递归遍历子目录
+                collectClassFiles(file, fileList);
+            }
+        }
     }
 
     private boolean hasStaticFields(Class<?> cls) {

--- a/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
+++ b/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
@@ -90,13 +90,13 @@ public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizRecycleEv
         }
         return classes;
     }
-    private static File[] collectClassFiles(File classDir) {
+    private File[] collectClassFiles(File classDir) {
         List<File> fileList = new ArrayList<>();
         collectClassFiles(classDir, fileList);
         return fileList.toArray(new File[0]);
     }
 
-    private static void collectClassFiles(File classDir, List<File> fileList) {
+    private void collectClassFiles(File classDir, List<File> fileList) {
         File[] files = classDir.listFiles();
         for (File file : files) {
             if (file.isFile() && file.getName().endsWith(".class")) {

--- a/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
+++ b/sofa-ark-plugin/clean-ark-plugin/src/main/java/com/alipay/sofa/ark/clean/HisBizStaticFieldCleaner.java
@@ -37,8 +37,8 @@ public class HisBizStaticFieldCleaner implements EventHandler<BeforeBizRecycleEv
     private final static ArkLogger LOGGER = ArkLoggerFactory.getLogger(HisBizStaticFieldCleaner.class);
 
     @Override
-    public void handleEvent(BeforeBizRecycleEvent beforeBizStopEvent) {
-        Biz biz = beforeBizStopEvent.getSource();
+    public void handleEvent(BeforeBizRecycleEvent beforeBizRecycleEvent) {
+        Biz biz = beforeBizRecycleEvent.getSource();
 
         try {
             if (biz != null && biz != ArkClient.getMasterBiz()) {


### PR DESCRIPTION
### Motivation:
After installation of the sofaark module, some static variables will never be recycled during JVM runtime, which may cause a side effect of occupying the metaspace.

### Modification:

I think it's possible to listen to the module uninstall event, and in the event handler, scan all classes that contain static variables. Then, load these classes through the bizclassloader and use reflection to assign these variables with null, in order to achieve the effect of garbage collection.
### Result:

Fixes #<GitHub issue number>. 

A new clean-ark-plugin Maven bundle has been added, which includes a processing class to handle the issue of garbage collection for static variables.