### PR TITLE
1.依据jarLocation解析BUG修复

### DIFF
--- a/.github/ISSUE_TEMPLATE/New_Requirement.md
+++ b/.github/ISSUE_TEMPLATE/New_Requirement.md
@@ -11,11 +11,5 @@ describe this requirement details with Chinese or English
 
 
 
-### 关联的语雀文档
-
-relative YuQue document if necessary
-
-
-
 ### 其它备注
 other notes if necessary

--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
@@ -166,6 +166,10 @@ public class JarUtils {
         }
         String artifactVersion = jarInfos[jarInfos.length - 1];
         String[] artifactVersionInfos = artifactVersion.split("-");
+        //对于多个类似version 直接返回null
+        if (messCheck(artifactVersionInfos)) {
+            return null;
+        }
         List<String> artifactInfos = new ArrayList<>();
         boolean getVersion = false;
         for (String info : artifactVersionInfos) {
@@ -180,6 +184,19 @@ public class JarUtils {
         }
         // if can't find any version from jar name, then we just return null to paas the declared check
         return null;
+    }
+
+    private static boolean messCheck(String[] artifactVersionInfos) {
+        if (artifactVersionInfos == null || artifactVersionInfos.length < 2) {
+            return Boolean.FALSE;
+        }
+        int messCount = 0;
+        for (String info : artifactVersionInfos) {
+            if (!StringUtils.isEmpty(info) && info.matches(VERSION_REGEX)) {
+                messCount++;
+            }
+        }
+        return messCount > 1;
     }
 
     private static String parseArtifactIdFromJarInJar(String jarLocation) throws IOException {

--- a/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/test/jar/JarUtilsTest.java
+++ b/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/test/jar/JarUtilsTest.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Properties;
 
 import static java.io.File.separator;
 
@@ -129,6 +130,16 @@ public class JarUtilsTest {
         URL jar = JarUtilsTest.class.getResource("/sample-biz-withjar.jar");
         String artifactId0 = JarUtils.parseArtifactId(jar.getFile()
                                                       + "!/lib/slf4j-api-1.7.30.jar!/");
+        Assert.assertEquals("slf4j-api", artifactId0);
+    }
+
+    @Test
+    public void testParseArtifactIdFromJarInJarPomWithDefault() {
+        Properties p = JarUtils.getDefaultArtifactIdProperties();
+        p.put("slf4j-api-1.7.30.jar", "slf4j-api");
+        URL jar = JarUtilsTest.class.getResource("/sample-biz-withjar.jar");
+        String artifactId0 = JarUtils.parseArtifactId(jar.getFile()
+                + "!/lib/slf4j-api-1.7.30.jar!/");
         Assert.assertEquals("slf4j-api", artifactId0);
     }
 }


### PR DESCRIPTION
### Motivation:

解决BUG  https://github.com/sofastack/sofa-ark/issues/647
JarUtils#doGetArtifactIdFromFileName对于某些jar路径解析出缺失

### Modification:
当对于jar路径中 例如：apm-toolkit-logback-1.x-8.2.0.jar，按照 - 切割后数组中有多个类似version的字符串则认为有可能字符串解析缺失，应该委托给本地IO去读取保证准确性，准确性 > 性能

### Result:

Fixes #<647>. 

If there is no issue then describe the changes introduced by this PR.
