### PR TITLE
resolve the bug for parseArtifactItem

### DIFF
--- a/sofa-ark-parent/core/api/src/main/java/com/alipay/sofa/ark/api/ArkClient.java
+++ b/sofa-ark-parent/core/api/src/main/java/com/alipay/sofa/ark/api/ArkClient.java
@@ -57,27 +57,13 @@ public class ArkClient {
     private static Biz               masterBiz;
     private static InjectionService  injectionService;
     private static String[]          arguments;
-    private final static File        bizInstallDirectory;
 
     private static EventAdminService eventAdminService;
 
-    static {
-        bizInstallDirectory = getBizInstallDirectory();
-    }
-
     private static File getBizInstallDirectory() {
-        File workingDir = FileUtils.createTempDir("sofa-ark");
         String configDir = ArkConfigs.getStringValue(Constants.CONFIG_INSTALL_BIZ_DIR);
-        if (!StringUtils.isEmpty(configDir)) {
-            if (!configDir.endsWith(File.separator)) {
-                configDir += File.separator;
-            }
-            workingDir = new File(configDir);
-            if (!workingDir.exists()) {
-                workingDir.mkdir();
-            }
-        }
-        return workingDir;
+        return StringUtils.isEmpty(configDir) ? FileUtils.createTempDir("sofa-ark") : FileUtils
+            .mkdir(configDir);
     }
 
     public static File createBizSaveFile(String bizName, String bizVersion, String fileSuffix) {
@@ -85,6 +71,7 @@ public class ArkClient {
         if (!StringUtils.isEmpty(fileSuffix)) {
             suffix = fileSuffix;
         }
+        File bizInstallDirectory = getBizInstallDirectory();
         return new File(bizInstallDirectory, bizName + "-" + bizVersion + "-" + suffix);
     }
 

--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/FileUtils.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/FileUtils.java
@@ -159,4 +159,23 @@ public class FileUtils {
             }
         }
     }
+
+    /**
+     * creates a new directory for given path
+     *
+     * @param dirPath dest path
+     * @return Dir
+     */
+    public static File mkdir(String dirPath) {
+        if (StringUtils.isEmpty(dirPath)) {
+            return null;
+        }
+        File dir = new File(dirPath);
+        if (!dir.exists()) {
+            // Recursive creation
+            dir.mkdirs();
+        }
+        return dir;
+    }
+
 }

--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/StringUtils.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/StringUtils.java
@@ -136,7 +136,7 @@ public class StringUtils {
      *
      * @param originalStr  the String to deal
      * @param spcChar      Special char
-     * @return str of removed
+     * @return removed string
      */
     public static String removeSpcChar(String originalStr, String spcChar) {
         AssertUtils.assertNotNull(spcChar, "SpcChar must not be null!");

--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/StringUtils.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/StringUtils.java
@@ -29,6 +29,7 @@ public class StringUtils {
     public static final int    CHAR_A       = 'A';
     public static final int    CHAR_Z       = 'Z';
     public static final int    CASE_GAP     = 32;
+    public static final String CR           = "\r";
 
     /**
      * <p>Checks if a String is empty ("") or null.</p>
@@ -124,5 +125,24 @@ public class StringUtils {
             }
         } while (ret && ++index < anotherString.length());
         return ret;
+    }
+
+    public static String removeCR(String originalStr) {
+        return removeSpcChar(originalStr, CR);
+    }
+
+    /**
+     * <p>Remove Special Characters, Such as \t、\n、\r</p>
+     *
+     * @param originalStr  the String to deal
+     * @param spcChar      Special char
+     * @return str of removed
+     */
+    public static String removeSpcChar(String originalStr, String spcChar) {
+        AssertUtils.assertNotNull(spcChar, "SpcChar must not be null!");
+        if (originalStr == null || originalStr.isEmpty()) {
+            return originalStr;
+        }
+        return originalStr.replaceAll(String.format("[%s]", spcChar),EMPTY_STRING);
     }
 }

--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/StringUtils.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/StringUtils.java
@@ -143,6 +143,6 @@ public class StringUtils {
         if (originalStr == null || originalStr.isEmpty()) {
             return originalStr;
         }
-        return originalStr.replaceAll(String.format("[%s]", spcChar),EMPTY_STRING);
+        return originalStr.replaceAll(String.format("[%s]", spcChar), EMPTY_STRING);
     }
 }

--- a/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/FileUtilsTest.java
+++ b/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/FileUtilsTest.java
@@ -63,4 +63,17 @@ public class FileUtilsTest {
         File file = new File(sampleBiz.getFile());
         Assert.assertNotNull(FileUtils.unzip(file, file.getAbsolutePath() + "-unpack"));
     }
+
+    @Test
+    public void testMkdir() {
+        Assert.assertNull(FileUtils.mkdir(""));
+        // test recursive creation
+        File newDir = FileUtils.mkdir("C:\\a\\b\\c");
+        Assert.assertNotNull(newDir);
+        // test for exist path
+        Assert.assertNotNull(FileUtils.mkdir("C:\\a\\b\\c"));
+        // del the dir
+        org.apache.commons.io.FileUtils.deleteQuietly(newDir);
+    }
+
 }

--- a/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/StringUtilsTest.java
+++ b/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/StringUtilsTest.java
@@ -96,4 +96,22 @@ public class StringUtilsTest {
         Assert.assertTrue(StringUtils.startWithToLowerCase("~Ab", "~ab"));
     }
 
+    @Test
+    public void testRemoveCR() {
+        Assert.assertNull(StringUtils.removeCR(null));
+        Assert.assertEquals("", StringUtils.removeCR(""));
+        Assert.assertEquals("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\n", StringUtils.removeCR("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r\n"));
+    }
+
+    @Test
+    public void testRemoveSpcChar() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            StringUtils.removeSpcChar("", null);
+        });
+        // 顺序无关
+        Assert.assertEquals("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test", StringUtils.removeSpcChar("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r\n\t", "\t\n\r"));
+        Assert.assertEquals("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test", StringUtils.removeSpcChar("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r\n", "\r\n"));
+        Assert.assertEquals("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r", StringUtils.removeSpcChar("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r\n", "\n"));
+    }
+
 }

--- a/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/StringUtilsTest.java
+++ b/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/StringUtilsTest.java
@@ -100,7 +100,8 @@ public class StringUtilsTest {
     public void testRemoveCR() {
         Assert.assertNull(StringUtils.removeCR(null));
         Assert.assertEquals("", StringUtils.removeCR(""));
-        Assert.assertEquals("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\n", StringUtils.removeCR("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r\n"));
+        Assert.assertEquals("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\n",
+            StringUtils.removeCR("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r\n"));
     }
 
     @Test
@@ -113,5 +114,4 @@ public class StringUtilsTest {
         Assert.assertEquals("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test", StringUtils.removeSpcChar("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r\n", "\r\n"));
         Assert.assertEquals("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r", StringUtils.removeSpcChar("com.alipay.sofa:biz-child1-child1:1.0.0:jar:test\r\n", "\n"));
     }
-
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/MavenUtils.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/MavenUtils.java
@@ -70,6 +70,7 @@ public class MavenUtils {
         if (StringUtils.isEmpty(lineContent)) {
             return null;
         }
+        lineContent = StringUtils.removeCR(lineContent);
         String[] contentInfos = lineContent.split(" ");
         if (contentInfos.length == 0) {
             return null;


### PR DESCRIPTION
### Motivation:

1. Windows环境下使用sofa-ark-maven-plugin打包时，生成的declaredLibraries中会有test的jar包；
2. ArkClient中BizInstallDir仅在动态加载Biz应用时使用，但会在启动时自动创建目录，尤其是/tmp目录，可能会因为权限问题导致启动失败，所以建议改为使用时创建

### Modification:

1. 在解析ArtifactItem前删除回车符(\r)；
2. 优化: Biz包路径创建时机修改为使用时创建

### Result:

已修改，已测试
