### PR TITLE
feat: 使用revision实现Maven模块统一版本管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.bak
 .classpath
 *.log
 logs/
+.flattened-pom.xml

--- a/change_version.sh
+++ b/change_version.sh
@@ -7,7 +7,7 @@ else
   	echo "The updated version is $1 !"
 fi
 
-currentVersion=`sed -n '/<project /,/<packaging/p' pom.xml | grep version | cut -d '>' -f2 | cut -d '<' -f1`
+currentVersion=`sed -n '/<revision>/p' pom.xml | cut -d '>' -f2 | cut -d '<' -f1`
 echo "The current version is $currentVersion"
 
 if [ `uname` == "Darwin" ] ;then
@@ -18,18 +18,7 @@ else
  	alias sed='sed -i'
 fi
 
-echo "Change version in root pom.xml ===>"
-sed "/<project /,/<packaging/ s/<version>.*<\/version>/<version>$1<\/version>/" pom.xml
-
-echo "Change version in subproject pom ===>"
-for filename in `find . -name "pom.xml" -mindepth 2`;do
-	echo "Deal with $filename"
-	sed "/<parent>/,/<\/parent>/ s/<version>.*<\/version>/<version>$1<\/version>/" $filename
-
-done
-
 for filename in `find . -name "README*.md"`;do
 	echo "Deal with $filename"
 	sed "/badge\/maven/! s/$currentVersion/$1/" $filename
-
 done

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-ark</artifactId>
-    <version>2.2.1</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -15,6 +15,7 @@
     </modules>
 
     <properties>
+        <revision>2.2.1</revision>
         <project.encoding>UTF-8</project.encoding>
         <java.version>1.8</java.version>
         <license.maven.plugin>3.0</license.maven.plugin>
@@ -25,6 +26,7 @@
         <maven.staging.plugin>1.6.7</maven.staging.plugin>
         <maven.gpg.pluign>1.5</maven.gpg.pluign>
         <jacoco.maven.plugin>0.8.4</jacoco.maven.plugin>
+        <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
     </properties>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -102,6 +104,34 @@
                 <configuration>
                     <configFile>${user.dir}/Formatter.xml</configFile>
                     <encoding>${project.encoding}</encoding>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <inherited>true</inherited>
+                <configuration>
+                    <!-- 避免IDE将 .flattened-pom.xml 自动识别为功能模块 -->
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
                 </configuration>
             </plugin>
 

--- a/sofa-ark-bom/pom.xml
+++ b/sofa-ark-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-parent/assembly/pom.xml
+++ b/sofa-ark-parent/assembly/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-all</artifactId>

--- a/sofa-ark-parent/core-impl/archive/pom.xml
+++ b/sofa-ark-parent/core-impl/archive/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core-impl</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-archive</artifactId>

--- a/sofa-ark-parent/core-impl/container/pom.xml
+++ b/sofa-ark-parent/core-impl/container/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core-impl</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-container</artifactId>

--- a/sofa-ark-parent/core-impl/pom.xml
+++ b/sofa-ark-parent/core-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-core-impl</artifactId>

--- a/sofa-ark-parent/core/api/pom.xml
+++ b/sofa-ark-parent/core/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-parent/core/common/pom.xml
+++ b/sofa-ark-parent/core/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-common</artifactId>

--- a/sofa-ark-parent/core/exception/pom.xml
+++ b/sofa-ark-parent/core/exception/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-exception</artifactId>

--- a/sofa-ark-parent/core/pom.xml
+++ b/sofa-ark-parent/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-core</artifactId>

--- a/sofa-ark-parent/core/spi/pom.xml
+++ b/sofa-ark-parent/core/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-spi</artifactId>

--- a/sofa-ark-parent/pom.xml
+++ b/sofa-ark-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-bom</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
         <relativePath>../sofa-ark-bom</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-ark-parent/support/ark-maven-plugin/pom.xml
+++ b/sofa-ark-parent/support/ark-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/sofa-ark-parent/support/ark-plugin-maven-plugin/pom.xml
+++ b/sofa-ark-parent/support/ark-plugin-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-common-springboot/pom.xml
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-common-springboot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-compatible-springboot1/pom.xml
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-compatible-springboot1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-compatible-springboot2/pom.xml
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-compatible-springboot2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/pom.xml
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-ark-parent/support/ark-support-starter/pom.xml
+++ b/sofa-ark-parent/support/ark-support-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-parent/support/ark-tools/pom.xml
+++ b/sofa-ark-parent/support/ark-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>sofa-ark-support</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sofa-ark-tools</artifactId>

--- a/sofa-ark-parent/support/pom.xml
+++ b/sofa-ark-parent/support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sofa-ark-plugin/config-ark-plugin/pom.xml
+++ b/sofa-ark-plugin/config-ark-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-bom</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
         <relativePath>../../sofa-ark-bom</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-ark-plugin/web-ark-plugin/pom.xml
+++ b/sofa-ark-plugin/web-ark-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sofa-ark-bom</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>2.2.1</version>
+        <version>${revision}</version>
         <relativePath>../../sofa-ark-bom</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
### Motivation:

在使用Maven多模块结构工程时，版本管理是一件很繁琐且容易出错的事情。每次升级版本号都要手动调整或者通过脚本方式去更改每一个子模块的版本号，非常的不方便，而且会改动所有的模块。

其实Maven已经提供了这种CI版本的管理方式，自 Maven 3.5.0-beta-1 开始，可以使用 ${revision}这样的变量作为版本占位符，可配合插件`flatten-maven-plugin`来实现全局版本统一管理。

### Result:

Fixes #690 
