### PR TITLE
Add a newFile method to handle file paths with spaces.

### DIFF
--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/bootstrap/BaseExecutableArchiveLauncher.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/bootstrap/BaseExecutableArchiveLauncher.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.ark.bootstrap;
 
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.loader.ExecutableArkBizJar;
 import com.alipay.sofa.ark.loader.archive.ExplodedArchive;
 import com.alipay.sofa.ark.loader.archive.JarFileArchive;
@@ -66,7 +67,7 @@ public abstract class BaseExecutableArchiveLauncher extends AbstractLauncher {
         if (path == null) {
             throw new IllegalStateException("Unable to determine code source archive");
         }
-        File root = new File(path);
+        File root = FileUtils.file(path);
         if (!root.exists()) {
             throw new IllegalStateException("Unable to determine code source archive from " + root);
         }

--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/bootstrap/ClasspathLauncher.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/bootstrap/ClasspathLauncher.java
@@ -16,10 +16,7 @@
  */
 package com.alipay.sofa.ark.bootstrap;
 
-import com.alipay.sofa.ark.common.util.AssertUtils;
-import com.alipay.sofa.ark.common.util.ClassLoaderUtils;
-import com.alipay.sofa.ark.common.util.ClassUtils;
-import com.alipay.sofa.ark.common.util.StringUtils;
+import com.alipay.sofa.ark.common.util.*;
 import com.alipay.sofa.ark.exception.ArkRuntimeException;
 import com.alipay.sofa.ark.loader.*;
 import com.alipay.sofa.ark.loader.archive.JarFileArchive;
@@ -115,7 +112,8 @@ public class ClasspathLauncher extends ArkLauncher {
                 throw new ArkRuntimeException("Duplicate Container Jar File Found.");
             }
 
-            return new JarContainerArchive(new JarFileArchive(new File(urlList.get(0).getFile())));
+            return new JarContainerArchive(new JarFileArchive(FileUtils.file(urlList.get(0)
+                .getFile())));
         }
 
         @Override
@@ -128,7 +126,8 @@ public class ClasspathLauncher extends ArkLauncher {
             }
 
             for (URL url : urlList) {
-                bizArchives.add(new JarBizArchive(new JarFileArchive(new File(url.getFile()))));
+                bizArchives
+                    .add(new JarBizArchive(new JarFileArchive(FileUtils.file(url.getFile()))));
             }
 
             return bizArchives;
@@ -140,8 +139,8 @@ public class ClasspathLauncher extends ArkLauncher {
 
             List<PluginArchive> pluginArchives = new ArrayList<>();
             for (URL url : urlList) {
-                pluginArchives
-                    .add(new JarPluginArchive(new JarFileArchive(new File(url.getFile()))));
+                pluginArchives.add(new JarPluginArchive(new JarFileArchive(FileUtils.file(url
+                    .getFile()))));
             }
 
             return pluginArchives;
@@ -177,9 +176,10 @@ public class ClasspathLauncher extends ArkLauncher {
                 if (classLocation.startsWith("file:")) {
                     classLocation = classLocation.substring("file:".length());
                 }
-                File file = classLocation == null ? null : new File(classLocation);
+                File file = classLocation == null ? null : FileUtils.file(classLocation);
                 while (file != null) {
-                    arkConfDir = new File(file.getPath() + File.separator + ARK_CONF_BASE_DIR);
+                    arkConfDir = FileUtils
+                        .file(file.getPath() + File.separator + ARK_CONF_BASE_DIR);
                     if (arkConfDir.exists() && arkConfDir.isDirectory()) {
                         break;
                     }

--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/EmbedClassPathArchive.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/EmbedClassPathArchive.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.ark.loader;
 
 import com.alipay.sofa.ark.bootstrap.ClasspathLauncher;
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.exception.ArkRuntimeException;
 import com.alipay.sofa.ark.loader.archive.JarFileArchive;
 import com.alipay.sofa.ark.spi.archive.Archive;
@@ -73,7 +74,8 @@ public class EmbedClassPathArchive extends ClasspathLauncher.ClassPathArchive {
                 }
 
             } else {
-                bizArchives.add(new JarBizArchive(new JarFileArchive(new File(url.getFile()))));
+                bizArchives
+                    .add(new JarBizArchive(new JarFileArchive(FileUtils.file(url.getFile()))));
             }
         }
         return bizArchives;
@@ -88,7 +90,7 @@ public class EmbedClassPathArchive extends ClasspathLauncher.ClassPathArchive {
     private Archive getArchiveFromJarEntry(URL jarUrl) throws IOException {
         String jarPath = jarUrl.getPath().substring(0, jarUrl.getPath().indexOf("!"));
         String bizPath = jarUrl.getPath().substring(jarUrl.getPath().indexOf("!") + 2);
-        List<Archive> nestedArchives = new JarFileArchive(new File(jarPath))
+        List<Archive> nestedArchives = new JarFileArchive(FileUtils.file(jarPath))
                 .getNestedArchives(entry -> entry.getName().equals(bizPath));
         if (nestedArchives.isEmpty()) {
             return null;
@@ -127,13 +129,13 @@ public class EmbedClassPathArchive extends ClasspathLauncher.ClassPathArchive {
         String file = url.getFile();
         if (file.contains(FILE_IN_JAR)) {
             int pos = file.indexOf(FILE_IN_JAR);
-            File fatJarFile = new File(file.substring(0, pos));
+            File fatJarFile = FileUtils.file(file.substring(0, pos));
             String nestedJar = file.substring(file.lastIndexOf("/") + 1);
             JarFileArchive fatJarFileArchive = new JarFileArchive(fatJarFile);
             List<Archive> matched = fatJarFileArchive.getNestedArchives(entry -> entry.getName().contains(nestedJar));
             return (JarFileArchive) matched.get(0);
         } else {
-            return new JarFileArchive(new File(file));
+            return new JarFileArchive(FileUtils.file(file));
         }
     }
 }

--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/archive/JarFileArchive.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/archive/JarFileArchive.java
@@ -24,6 +24,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.loader.jar.JarFile;
 import com.alipay.sofa.ark.loader.data.RandomAccessData.ResourceAccess;
 import com.alipay.sofa.ark.spi.archive.Archive;
@@ -125,7 +126,7 @@ public class JarFileArchive implements Archive {
 
     private File getTempUnpackFolder() {
         if (this.tempUnpackFolder == null) {
-            File tempFolder = new File(System.getProperty("java.io.tmpdir"));
+            File tempFolder = FileUtils.file(System.getProperty("java.io.tmpdir"));
             this.tempUnpackFolder = createUnpackFolder(tempFolder);
         }
         return this.tempUnpackFolder;
@@ -134,7 +135,7 @@ public class JarFileArchive implements Archive {
     private File createUnpackFolder(File parent) {
         int attempts = 0;
         while (attempts++ < 1000) {
-            String fileName = new File(this.jarFile.getName()).getName();
+            String fileName = FileUtils.file(this.jarFile.getName()).getName();
             File unpackFolder = new File(parent, fileName + "-spring-boot-libs-"
                                                  + UUID.randomUUID());
             if (unpackFolder.mkdirs()) {

--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/Handler.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/Handler.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.ark.loader.jar;
 
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.common.util.StringUtils;
 
 import java.io.File;
@@ -289,7 +290,7 @@ public class Handler extends URLStreamHandler {
                 throw new IllegalStateException("Not a file URL");
             }
             String path = name.substring(FILE_PROTOCOL.length());
-            File file = new File(URLDecoder.decode(path, "UTF-8"));
+            File file = FileUtils.file(path);
             Map<File, JarFile> cache = rootFileCache.get();
             JarFile result = (cache == null ? null : cache.get(file));
             if (result == null) {

--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/jar/JarUtils.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.ark.loader.jar;
 
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.common.util.StringUtils;
 import com.alipay.sofa.ark.loader.archive.JarFileArchive;
 import com.alipay.sofa.ark.spi.archive.Archive;
@@ -107,7 +108,7 @@ public class JarUtils {
         } else {
             // is not from test classpath, for example install uncompressed modules, just return null
             // search for pom.properties
-            File pomPropertiesFile = searchPomProperties(new File(libraryFile));
+            File pomPropertiesFile = searchPomProperties(FileUtils.file(libraryFile));
             if (pomPropertiesFile != null && pomPropertiesFile.exists()) {
                 pomPropertiesPath = pomPropertiesFile.getAbsolutePath();
             } else {
@@ -118,7 +119,7 @@ public class JarUtils {
 
         String artifactId = null;
         if (!StringUtils.isEmpty(pomPropertiesPath)) {
-            try (InputStream inputStream = Files.newInputStream(new File(pomPropertiesPath)
+            try (InputStream inputStream = Files.newInputStream(FileUtils.file(pomPropertiesPath)
                 .toPath())) {
                 Properties properties = new Properties();
                 properties.load(inputStream);
@@ -227,7 +228,7 @@ public class JarUtils {
     private static String parseArtifactIdFromJarInJar(String jarLocation) throws IOException {
         String rootPath = jarLocation.substring(0, jarLocation.lastIndexOf(JAR_SEPARATOR));
         String subNestedPath =  jarLocation.substring(jarLocation.lastIndexOf(JAR_SEPARATOR) + 2);
-        com.alipay.sofa.ark.loader.jar.JarFile jarFile = new com.alipay.sofa.ark.loader.jar.JarFile(new File(rootPath));
+        com.alipay.sofa.ark.loader.jar.JarFile jarFile = new com.alipay.sofa.ark.loader.jar.JarFile(FileUtils.file(rootPath));
         JarFileArchive jarFileArchive = new JarFileArchive(jarFile);
         List<Archive> archives = jarFileArchive.getNestedArchives(entry -> !StringUtils.isEmpty(entry.getName()) && entry.getName().equals(subNestedPath));
 
@@ -251,7 +252,7 @@ public class JarUtils {
         //  /xxx/xxx/xxx-starter-1.0.0-SNAPSHOT.jar!/BOOT-INF/lib/xxx2-starter-1.1.4-SNAPSHOT-ark-biz.jar!/lib/xxx3-230605-sofa.jar
         String[] js = jarLocation.split(JAR_SEPARATOR, -1);
         com.alipay.sofa.ark.loader.jar.JarFile rJarFile = new com.alipay.sofa.ark.loader.jar.JarFile(
-            new File(js[0]));
+            FileUtils.file(js[0]));
         for (int i = 1; i < js.length; i++) {
             String jPath = js[i];
             if (jPath == null || jPath.isEmpty()) {
@@ -269,7 +270,7 @@ public class JarUtils {
     }
 
     private static String parseArtifactIdFromJar(String jarLocation) throws IOException {
-        jarLocation = URLDecoder.decode(jarLocation, "UTF-8");
+        jarLocation = FileUtils.decodePath(jarLocation);
         try (JarFile jarFile = new JarFile(jarLocation)) {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {

--- a/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/bootstrap/ClasspathLauncherTest.java
+++ b/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/bootstrap/ClasspathLauncherTest.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.ark.bootstrap;
 
 import com.alipay.sofa.ark.common.util.ClassLoaderUtils;
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.loader.EmbedClassPathArchive;
 import com.alipay.sofa.ark.loader.archive.JarFileArchive;
 import com.alipay.sofa.ark.spi.archive.Archive;
@@ -52,7 +53,7 @@ public class ClasspathLauncherTest {
         List<String> mockArguments = new ArrayList<>();
         String filePath = ClasspathLauncherTest.class.getClassLoader()
             .getResource("SampleClass.class").getPath();
-        String workingPath = new File(filePath).getParent();
+        String workingPath = FileUtils.file(filePath).getParent();
         mockArguments.add(String.format("-javaagent:%s", workingPath));
 
         RuntimeMXBean runtimeMXBean = Mockito.mock(RuntimeMXBean.class);
@@ -92,7 +93,7 @@ public class ClasspathLauncherTest {
         Assert.assertEquals(1, agentUrl.length);
 
         List<URL> urls = new ArrayList<>();
-        JarFileArchive jarFileArchive = new JarFileArchive(new File(url.getFile()));
+        JarFileArchive jarFileArchive = new JarFileArchive(FileUtils.file(url.getFile()));
         List<Archive> archives = jarFileArchive.getNestedArchives(this::isNestedArchive);
         for (Archive archive : archives) {
             urls.add(archive.getUrl());

--- a/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/EmbedClassPathArchiveTest.java
+++ b/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/EmbedClassPathArchiveTest.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.ark.loader;
 
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.spi.archive.BizArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class EmbedClassPathArchiveTest {
     public void testGetContainerArchive() throws Exception {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         URL springbootFatJar = cl.getResource("sample-springboot-fat-biz.jar");
-        JarFileArchive jarFileArchive = new JarFileArchive(new File(springbootFatJar.getFile()));
+        JarFileArchive jarFileArchive = new JarFileArchive(FileUtils.file(springbootFatJar.getFile()));
         Iterator<Archive> archives = jarFileArchive.getNestedArchives(this::isNestedArchive,null);
         List<URL> urls = new ArrayList<>();
         while (archives.hasNext()){
@@ -75,7 +76,7 @@ public class EmbedClassPathArchiveTest {
     public void testStaticCombineGetBizArchives() throws Exception {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         URL springbootFatJar = cl.getResource("static-combine-demo.jar");
-        JarFileArchive jarFileArchive = new JarFileArchive(new File(springbootFatJar.getFile()));
+        JarFileArchive jarFileArchive = new JarFileArchive(FileUtils.file(springbootFatJar.getFile()));
         Iterator<org.springframework.boot.loader.archive.Archive> archives = jarFileArchive.getNestedArchives(this::isNestedArchive,null);
         List<URL> urls = new ArrayList<>();
         while (archives.hasNext()){

--- a/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/ExplodedBizArchiveTest.java
+++ b/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/ExplodedBizArchiveTest.java
@@ -35,7 +35,7 @@ public class ExplodedBizArchiveTest {
     public void testCreate() throws IOException {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         URL arkBizJar = cl.getResource("sample-biz-withjar.jar");
-        File unpack = FileUtils.unzip(new File(arkBizJar.getFile()), arkBizJar.getFile()
+        File unpack = FileUtils.unzip(FileUtils.file(arkBizJar.getFile()), arkBizJar.getFile()
                                                                      + "-unpack");
         ExplodedBizArchive archive = new ExplodedBizArchive(unpack);
         Assert.assertNotNull(archive.getManifest());

--- a/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/test/base/BaseTest.java
+++ b/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/test/base/BaseTest.java
@@ -117,13 +117,14 @@ public abstract class BaseTest {
 
     private static byte[] fetchResource(String resourceName) throws IOException {
         URL resource = BaseTest.class.getClassLoader().getResource(resourceName);
-        RandomAccessDataFile dataFile = new RandomAccessDataFile(new File(resource.getFile()));
+        RandomAccessDataFile dataFile = new RandomAccessDataFile(
+            com.alipay.sofa.ark.common.util.FileUtils.file(resource.getFile()));
         return Bytes.get(dataFile);
     }
 
     public static File getTmpDir() {
         String tmpPath = System.getProperty("java.io.tmpdir");
-        return new File(tmpPath);
+        return com.alipay.sofa.ark.common.util.FileUtils.file(tmpPath);
     }
 
     public static File getWorkspace() {

--- a/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/test/jar/JarUtilsTest.java
+++ b/sofa-ark-parent/core-impl/archive/src/test/java/com/alipay/sofa/ark/loader/test/jar/JarUtilsTest.java
@@ -145,7 +145,7 @@ public class JarUtilsTest {
         String fullPath = root.getPath() + "space directory";
         String jarLocation = fullPath + "/junit-4.12.jar";
         FileUtils.mkdir(fullPath);
-        Files.copy(new File(jar.getFile()), new File(jarLocation));
+        Files.copy(FileUtils.file(jar.getFile()), FileUtils.file(jarLocation));
 
         URL url = JarUtilsTest.class.getResource("/space directory/junit-4.12.jar");
         Method method = JarUtils.class.getDeclaredMethod("parseArtifactIdFromJar", String.class);

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/ArkContainer.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/ArkContainer.java
@@ -20,6 +20,7 @@ import com.alipay.sofa.ark.api.ArkConfigs;
 import com.alipay.sofa.ark.bootstrap.ClasspathLauncher.ClassPathArchive;
 import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
 import com.alipay.sofa.ark.common.util.AssertUtils;
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.common.util.StringUtils;
 import com.alipay.sofa.ark.container.pipeline.DeployBizStage;
 import com.alipay.sofa.ark.container.pipeline.HandleArchiveStage;
@@ -92,8 +93,7 @@ public class ArkContainer {
             LaunchCommand launchCommand = LaunchCommand.parse(args);
             if (launchCommand.isExecutedByCommandLine()) {
                 ExecutableArkBizJar executableArchive;
-                File rootFile = new File(URLDecoder.decode(launchCommand.getExecutableArkBizJar()
-                    .getFile()));
+                File rootFile = FileUtils.file(launchCommand.getExecutableArkBizJar().getFile());
                 if (rootFile.isDirectory()) {
                     executableArchive = new ExecutableArkBizJar(new ExplodedArchive(rootFile));
                 } else {

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceImpl.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceImpl.java
@@ -109,7 +109,7 @@ public class BizFactoryServiceImpl implements BizFactoryService {
     public Biz createBiz(File file) throws IOException {
         BizArchive bizArchive;
         if (ArkConfigs.isEmbedEnable()) {
-            File unpackFile = new File(file.getAbsolutePath() + "-unpack");
+            File unpackFile = FileUtils.file(file.getAbsolutePath() + "-unpack");
             if (!unpackFile.exists()) {
                 unpackFile = FileUtils.unzip(file, file.getAbsolutePath() + "-unpack");
             }

--- a/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/ArkContainerTest.java
+++ b/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/ArkContainerTest.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.ark.container;
 
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.exception.ArkRuntimeException;
 import com.alipay.sofa.ark.loader.ExecutableArkBizJar;
 import com.alipay.sofa.ark.loader.archive.JarFileArchive;
@@ -56,7 +57,7 @@ public class ArkContainerTest extends BaseTest {
     @Test
     public void testStop() throws Exception {
         ArkContainer arkContainer = new ArkContainer(new ExecutableArkBizJar(new JarFileArchive(
-            new File((jarURL.getFile())))));
+            FileUtils.file((jarURL.getFile())))));
         arkContainer.start();
         arkContainer.stop();
         Assert.assertFalse(arkContainer.isRunning());

--- a/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/BaseTest.java
+++ b/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/BaseTest.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.ark.container;
 
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.container.model.BizModel;
 import com.alipay.sofa.ark.container.model.PluginModel;
 import com.alipay.sofa.ark.container.pipeline.RegisterServiceStage;
@@ -76,7 +77,7 @@ public class BaseTest {
         List<String> mockArguments = new ArrayList<>();
         String filePath = this.getClass().getClassLoader()
                 .getResource("SampleClass.class").getPath();
-        String workingPath = new File(filePath).getParent();
+        String workingPath = FileUtils.file(filePath).getParent();
         mockArguments.add(String.format("javaaget:%s", workingPath));
         mockArguments.add(String.format("-javaagent:%s", workingPath));
         mockArguments.add(String.format("-javaagent:%s=xx", workingPath));

--- a/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/api/ArkClientTest.java
+++ b/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/api/ArkClientTest.java
@@ -188,7 +188,7 @@ public class ArkClientTest extends BaseTest {
     public void testSwitchBiz() throws Throwable {
         testUninstallBiz();
         // test switch biz
-        ClientResponse response = ArkClient.installBiz(new File(bizUrl1.getFile()));
+        ClientResponse response = ArkClient.installBiz(FileUtils.file(bizUrl1.getFile()));
         Assert.assertEquals(ResponseCode.SUCCESS, response.getCode());
         BizInfo bizInfo = response.getBizInfos().iterator().next();
         Assert.assertEquals(BizState.ACTIVATED, bizInfo.getBizState());

--- a/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceTest.java
+++ b/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceTest.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.ark.container.service.biz;
 
 import com.alipay.sofa.ark.api.ArkConfigs;
+import com.alipay.sofa.ark.common.util.FileUtils;
 import com.alipay.sofa.ark.container.BaseTest;
 import com.alipay.sofa.ark.container.service.ArkServiceContainerHolder;
 import com.alipay.sofa.ark.spi.constant.Constants;
@@ -63,11 +64,11 @@ public class BizFactoryServiceTest extends BaseTest {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
 
         URL samplePlugin = cl.getResource("sample-plugin.jar");
-        Plugin plugin = pluginFactoryService.createPlugin(new File(samplePlugin.getFile()));
+        Plugin plugin = pluginFactoryService.createPlugin(FileUtils.file(samplePlugin.getFile()));
         pluginManagerService.registerPlugin(plugin);
 
         URL sampleBiz = cl.getResource("sample-biz.jar");
-        Biz biz = bizFactoryService.createBiz(new File(sampleBiz.getFile()));
+        Biz biz = bizFactoryService.createBiz(FileUtils.file(sampleBiz.getFile()));
         bizManagerService.registerBiz(biz);
         Assert.assertNotNull(biz);
         Assert.assertNotNull(biz.getBizClassLoader().getResource(Constants.ARK_PLUGIN_MARK_ENTRY));
@@ -86,7 +87,7 @@ public class BizFactoryServiceTest extends BaseTest {
         BizOperation bizOperation = new BizOperation();
         String mockVersion = "mock version";
         bizOperation.setBizVersion(mockVersion);
-        Biz biz = bizFactoryService.createBiz(bizOperation, new File(sampleBiz.getFile()));
+        Biz biz = bizFactoryService.createBiz(bizOperation, FileUtils.file(sampleBiz.getFile()));
         Assert.assertEquals(biz.getBizVersion(), mockVersion);
     }
 
@@ -94,7 +95,7 @@ public class BizFactoryServiceTest extends BaseTest {
     public void testPackageInfo() throws Throwable {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         URL samplePlugin = cl.getResource("sample-ark-plugin.jar");
-        Plugin plugin = pluginFactoryService.createPlugin(new File(samplePlugin.getFile()));
+        Plugin plugin = pluginFactoryService.createPlugin(FileUtils.file(samplePlugin.getFile()));
         ClassLoader pluginClassLoader = plugin.getPluginClassLoader();
         pluginManagerService.registerPlugin(plugin);
         Class mdc = pluginClassLoader.loadClass("org.slf4j.MDC");

--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/ClassLoaderUtils.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/ClassLoaderUtils.java
@@ -83,7 +83,7 @@ public class ClassLoaderUtils {
             argument = argument.substring(JAVA_AGENT_MARK.length());
             try {
                 String path = argument.split(JAVA_AGENT_OPTION_MARK)[0];
-                URL url = new File(path).getCanonicalFile().toURI().toURL();
+                URL url = FileUtils.file(path).getCanonicalFile().toURI().toURL();
                 agentPaths.add(url);
                 processSkyWalking(path, agentPaths);
             } catch (Throwable e) {
@@ -91,6 +91,7 @@ public class ClassLoaderUtils {
             }
         }
         return agentPaths.toArray(new URL[] {});
+
     }
 
     /**
@@ -102,7 +103,7 @@ public class ClassLoaderUtils {
     public static void processSkyWalking(final String path, final List<URL> agentPaths) throws MalformedURLException, IOException {
         if (path.contains(SKYWALKING_AGENT_JAR)) {
             for (String mountFolder : SKYWALKING_MOUNT_DIR) {
-                File folder = new File(new File(path).getCanonicalFile().getParentFile(), mountFolder);
+                File folder = new File(FileUtils.file(path).getCanonicalFile().getParentFile(), mountFolder);
                 if (folder.exists() && folder.isDirectory()) {
                     String[] jarFileNames = folder.list((dir, name) -> name.endsWith(".jar"));
                     for (String fileName: jarFileNames) {
@@ -128,7 +129,7 @@ public class ClassLoaderUtils {
         for (String classpathEntry : classpathEntries) {
             URL url = null;
             try {
-                url = new File(classpathEntry).toURI().toURL();
+                url = FileUtils.file(classpathEntry).toURI().toURL();
             } catch (MalformedURLException e) {
                 e.printStackTrace();
                 throw new ArkRuntimeException("Failed to get urls from " + classLoader, e);

--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/FileUtils.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/util/FileUtils.java
@@ -18,11 +18,9 @@ package com.alipay.sofa.ark.common.util;
 
 import com.alipay.sofa.ark.exception.ArkRuntimeException;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -77,7 +75,7 @@ public class FileUtils {
      * temporary directory (as defined by the {@code java.io.tmpdir} system
      */
     public static File createTempDir(String subPath) {
-        File baseDir = new File(System.getProperty("java.io.tmpdir"));
+        File baseDir = FileUtils.file(System.getProperty("java.io.tmpdir"));
         File tempDir = new File(baseDir, subPath);
         if (tempDir.exists()) {
             return tempDir;
@@ -119,14 +117,14 @@ public class FileUtils {
                 ZipEntry entry = entries.nextElement();
                 if (entry.isDirectory()) {
                     String dirPath = targetPath + File.separator + entry.getName();
-                    File dir = new File(dirPath);
+                    File dir = FileUtils.file(dirPath);
                     dir.mkdirs();
                 } else {
                     InputStream inputStream = null;
                     FileOutputStream fileOutputStream = null;
                     try {
                         inputStream = zipFile.getInputStream(entry);
-                        File file = new File(targetPath + File.separator + entry.getName());
+                        File file = FileUtils.file(targetPath + File.separator + entry.getName());
                         if (!file.exists()) {
                             File fileParent = file.getParentFile();
                             if (!fileParent.exists()) {
@@ -152,7 +150,7 @@ public class FileUtils {
                     }
                 }
             }
-            return new File(targetPath);
+            return FileUtils.file(targetPath);
         } finally {
             if (zipFile != null) {
                 zipFile.close();
@@ -170,12 +168,49 @@ public class FileUtils {
         if (StringUtils.isEmpty(dirPath)) {
             return null;
         }
-        File dir = new File(dirPath);
+        File dir = FileUtils.file(dirPath);
         if (!dir.exists()) {
             // Recursive creation
             dir.mkdirs();
         }
         return dir;
+    }
+
+    /**
+     * decode the given path if the path has spaces
+     *
+     * @param path dest path
+     * @return decoded path
+     */
+    public static String decodePath(String path) {
+        try {
+            return URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            // return source string when occur an exception
+            return path;
+        }
+    }
+
+    /**
+     * creates a new file for given path.
+     * first, we check if the path is encoded before creating the File object
+     *
+     * @param path file path
+     * @return new File
+     */
+    public static File file(String path) {
+        return new File(decodePath(path));
+    }
+
+    /**
+     * creates a new file for given path.
+     *
+     * @param parent parent path
+     * @param path child path
+     * @return new File
+     */
+    public static File file(String parent, String path) {
+        return new File(decodePath(parent), path);
     }
 
 }

--- a/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/ClassLoaderUtilTest.java
+++ b/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/ClassLoaderUtilTest.java
@@ -99,7 +99,7 @@ public class ClassLoaderUtilTest {
             for (String classpathEntry : classpathEntries) {
                 URL url = null;
                 try {
-                    url = new File(classpathEntry).toURI().toURL();
+                    url = FileUtils.file(classpathEntry).toURI().toURL();
                 } catch (MalformedURLException e) {
                     e.printStackTrace();
                     throw new ArkRuntimeException("Failed to get urls from " + appClassLoader, e);

--- a/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/FileUtilsTest.java
+++ b/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/util/FileUtilsTest.java
@@ -54,13 +54,13 @@ public class FileUtilsTest {
     @Test
     public void testSHA1Hash() throws IOException {
         URL url = this.getClass().getResource(this.getClass().getSimpleName() + ".class");
-        Assert.assertNotNull(FileUtils.sha1Hash(new File(url.getFile())));
+        Assert.assertNotNull(FileUtils.sha1Hash(FileUtils.file(url.getFile())));
     }
 
     @Test
     public void testUnzip() throws IOException {
         URL sampleBiz = this.getClass().getClassLoader().getResource("sample-biz.jar");
-        File file = new File(sampleBiz.getFile());
+        File file = FileUtils.file(sampleBiz.getFile());
         Assert.assertNotNull(FileUtils.unzip(file, file.getAbsolutePath() + "-unpack"));
     }
 
@@ -74,6 +74,28 @@ public class FileUtilsTest {
         Assert.assertNotNull(FileUtils.mkdir("C:\\a\\b\\c"));
         // del the dir
         org.apache.commons.io.FileUtils.deleteQuietly(newDir);
+    }
+
+    @Test
+    public void testDecodePath() {
+        String path = "C:\\temp dir\\b\\c";
+        String encodedPath = "C:\\temp%20dir\\b\\c";
+        Assert.assertEquals(path, FileUtils.decodePath(path));
+        Assert.assertEquals(path, FileUtils.decodePath(encodedPath));
+    }
+
+    @Test
+    public void testNewFile() throws IOException {
+        String dir = "C:\\temp dir\\b\\c";
+        String encodedPath = "C:\\temp%20dir\\b\\c";
+        FileUtils.mkdir(dir);
+        org.apache.commons.io.FileUtils.touch(new File(dir, "test.txt"));
+        File file = FileUtils.file(encodedPath, "test.txt");
+        Assert.assertNotNull(file);
+        Assert.assertTrue(file.exists());
+
+        file = new File(encodedPath, "test.txt");
+        Assert.assertFalse(file.exists());
     }
 
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
@@ -351,7 +351,8 @@ public class RepackageMojo extends TreeMojo {
         if (gitDirectory != null && gitDirectory.exists()) {
             return gitDirectory;
         }
-        return new File(rootProject.getBasedir().getAbsolutePath() + "/.git");
+        return com.alipay.sofa.ark.common.util.FileUtils.file(rootProject.getBasedir()
+            .getAbsolutePath() + "/.git");
     }
 
     private void parseArtifactItems(DependencyNode rootNode, Set<ArtifactItem> result) {
@@ -383,7 +384,7 @@ public class RepackageMojo extends TreeMojo {
         // dependency:tree
         String outputPath = baseDir.getAbsolutePath() + "/deps.log." + System.currentTimeMillis();
         InvocationRequest request = new DefaultInvocationRequest();
-        request.setPomFile(new File(baseDir.getAbsolutePath() + "/pom.xml"));
+        request.setPomFile(com.alipay.sofa.ark.common.util.FileUtils.file(baseDir.getAbsolutePath() + "/pom.xml"));
 
         List<String> goals = Stream.of("dependency:tree", "-DappendOutput=true",
             "-DoutputFile=" + outputPath).collect(Collectors.toList());
@@ -413,7 +414,7 @@ public class RepackageMojo extends TreeMojo {
         } catch (MavenInvocationException | IOException e) {
             throw new MojoExecutionException("execute dependency:tree failed", e);
         } finally {
-            File outputFile = new File(outputPath);
+            File outputFile = com.alipay.sofa.ark.common.util.FileUtils.file(outputPath);
             if (outputFile.exists()) {
                 outputFile.delete();
             }
@@ -645,7 +646,7 @@ public class RepackageMojo extends TreeMojo {
 
     protected void extensionExcludeArtifacts(String extraResources) {
         try {
-            File configFile = new File(extraResources);
+            File configFile = com.alipay.sofa.ark.common.util.FileUtils.file(extraResources);
             if (configFile.exists()) {
                 BufferedReader bufferedReader = new BufferedReader(new FileReader(configFile));
                 String dataLine;

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
@@ -165,8 +165,10 @@ public class RepackageMojoTest {
                                       + "user-settings-test.xml";
         String globalSettingsFilePath = System.getProperty("user.home") + File.separator
                                         + "global-settings-test.xml";
-        File userSettingsFile = new File(userSettingsFilePath);
-        File globalSettingsFile = new File(globalSettingsFilePath);
+        File userSettingsFile = com.alipay.sofa.ark.common.util.FileUtils
+            .file(userSettingsFilePath);
+        File globalSettingsFile = com.alipay.sofa.ark.common.util.FileUtils
+            .file(globalSettingsFilePath);
         InvocationRequest request = new DefaultInvocationRequest();
         invokeSetSettingsLocation(request, userSettingsFilePath, globalSettingsFilePath);
         Assert.assertNull(request.getUserSettingsFile());
@@ -190,8 +192,10 @@ public class RepackageMojoTest {
                                            String globalSettingsFilePath) throws Exception {
         RepackageMojo repackageMojo = new RepackageMojo();
         MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
-        executionRequest.setUserSettingsFile(new File(userSettingsFilePath));
-        executionRequest.setGlobalSettingsFile(new File(globalSettingsFilePath));
+        executionRequest.setUserSettingsFile(com.alipay.sofa.ark.common.util.FileUtils
+            .file(userSettingsFilePath));
+        executionRequest.setGlobalSettingsFile(com.alipay.sofa.ark.common.util.FileUtils
+            .file(globalSettingsFilePath));
         // 构造对象
         MavenSession mavenSession = new MavenSession(null, executionRequest, null,
             new ArrayList<>());
@@ -325,8 +329,8 @@ public class RepackageMojoTest {
 
         DefaultArtifact artifact = new DefaultArtifact("group1", "artifact1", "1.0", "compile", "",
             null, new DefaultArtifactHandler());
-        artifact
-            .setFile(new File(getClass().getClassLoader().getResource("excludes.txt").getPath()));
+        artifact.setFile(com.alipay.sofa.ark.common.util.FileUtils.file(getClass().getClassLoader()
+            .getResource("excludes.txt").getPath()));
         mavenProject.setArtifact(artifact);
 
         Set<Artifact> artifacts = new HashSet<>();

--- a/sofa-ark-plugin/netty-ark-plugin/pom.xml
+++ b/sofa-ark-plugin/netty-ark-plugin/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>sofa-ark-common</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
### Motivation

文件路径包含空格时，创建file对象时失败。
全局替换`new File`为`FileUtils.file()`，创建file对象时先解码decode，再创建File文件。

### Result

Resolved or fixed #724 . 
