### PR TITLE
支持对tomcat进行配置

### DIFF
--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/ArkServletAutoConfiguration.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/ArkServletAutoConfiguration.java
@@ -20,17 +20,22 @@ import com.alipay.sofa.ark.springboot.condition.ConditionalOnArkEnabled;
 import com.alipay.sofa.ark.springboot.web.ArkTomcatServletWebServerFactory;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.coyote.UpgradeProtocol;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatProtocolHandlerCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import javax.servlet.Servlet;
+import java.util.stream.Collectors;
 
 /**
  * @author qilong.zql
@@ -50,8 +55,17 @@ public class ArkServletAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean(ArkTomcatServletWebServerFactory.class)
-        public TomcatServletWebServerFactory tomcatServletWebServerFactory() {
-            return new ArkTomcatServletWebServerFactory();
+        public TomcatServletWebServerFactory tomcatServletWebServerFactory(ObjectProvider<TomcatConnectorCustomizer> connectorCustomizers,
+                                                                           ObjectProvider<TomcatContextCustomizer> contextCustomizers,
+                                                                           ObjectProvider<TomcatProtocolHandlerCustomizer<?>> protocolHandlerCustomizers) {
+            ArkTomcatServletWebServerFactory factory = new ArkTomcatServletWebServerFactory();
+            factory.getTomcatConnectorCustomizers().addAll(
+                connectorCustomizers.orderedStream().collect(Collectors.toList()));
+            factory.getTomcatContextCustomizers().addAll(
+                contextCustomizers.orderedStream().collect(Collectors.toList()));
+            factory.getTomcatProtocolHandlerCustomizers().addAll(
+                protocolHandlerCustomizers.orderedStream().collect(Collectors.toList()));
+            return factory;
         }
 
     }


### PR DESCRIPTION
### Motivation

springboot原本是支持对tomcat各个组件进行配置的，而ArkServletAutoConfiguration.EmbeddedArkTomcat中的实现，丢失了对tomcat的组件配置的支持。

### Modification

这个pr就是恢复对tomcat的组件配置的支持。

### Result
与此相关的issue 可见：
https://github.com/koupleless/koupleless/issues/26 
