### PR TITLE
sofa-ark-maven-plugin supports jdk17 record symbol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </modules>
 
     <properties>
-        <sofa.ark.version>3.1.2</sofa.ark.version>
+        <sofa.ark.version>3.1.3-SNAPSHOT</sofa.ark.version>
         <sofa.ark.version.old>3.1.1</sofa.ark.version.old>
         <project.encoding>UTF-8</project.encoding>
         <java.version>17</java.version>

--- a/sofa-ark-parent/support/ark-tools/src/main/java/com/alipay/sofa/ark/tools/MainClassFinder.java
+++ b/sofa-ark-parent/support/ark-tools/src/main/java/com/alipay/sofa/ark/tools/MainClassFinder.java
@@ -151,7 +151,7 @@ public class MainClassFinder {
         private boolean           mainMethodFound;
 
         ClassDescriptor() {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM8);
         }
 
         @Override


### PR DESCRIPTION
### Motivation

jdk17 使用 sofa-ark-maven-plugin 构建模块报错：

> Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-cli of goal com.alipay.sofa:sofa-ark-maven-plugin:3.1.2:repackage failed: Records requires ASM8

### Modification

update ASM7 to ASM8 in com.alipay.sofa.ark.tools.MainClassFinder.ClassDescriptor#ClassDescriptor

### Result

Resolved or fixed #910  
