### PR TITLE
fix：sofa-ark-plugin-maven-plugin remove unnecessary shade lib

### DIFF
--- a/sofa-ark-parent/support/ark-plugin-maven-plugin/src/main/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojo.java
+++ b/sofa-ark-parent/support/ark-plugin-maven-plugin/src/main/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojo.java
@@ -281,9 +281,8 @@ public class ArkPluginMojo extends AbstractMojo {
      */
     protected void addArkPluginArtifact(Archiver archiver, Set<Artifact> dependencies,
                                         Set<Artifact> conflicts) {
-        addArtifact(archiver, project.getArtifact(), conflicts.contains(project.getArtifact()));
         for (Artifact artifact : dependencies) {
-            if (Repackager.isZip(artifact.getFile())) {
+            if (Repackager.isZip(artifact.getFile()) && !isShadeJar(artifact)) {
                 addArtifact(archiver, artifact, conflicts.contains(artifact));
             }
         }

--- a/sofa-ark-parent/support/ark-plugin-maven-plugin/src/main/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojo.java
+++ b/sofa-ark-parent/support/ark-plugin-maven-plugin/src/main/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojo.java
@@ -282,7 +282,7 @@ public class ArkPluginMojo extends AbstractMojo {
     protected void addArkPluginArtifact(Archiver archiver, Set<Artifact> dependencies,
                                         Set<Artifact> conflicts) {
         for (Artifact artifact : dependencies) {
-            if (Repackager.isZip(artifact.getFile()) && !isShadeJar(artifact)) {
+            if (Repackager.isZip(artifact.getFile())) {
                 addArtifact(archiver, artifact, conflicts.contains(artifact));
             }
         }

--- a/sofa-ark-parent/support/ark-plugin-maven-plugin/src/test/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojoTest.java
+++ b/sofa-ark-parent/support/ark-plugin-maven-plugin/src/test/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojoTest.java
@@ -166,4 +166,5 @@ public class ArkPluginMojoTest {
         assertEquals("c,d", properties.getProperty("import-resources"));
         assertEquals("", properties.getProperty("import-packages"));
     }
+
 }

--- a/sofa-ark-parent/support/ark-plugin-maven-plugin/src/test/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojoTest.java
+++ b/sofa-ark-parent/support/ark-plugin-maven-plugin/src/test/java/com/alipay/sofa/ark/plugin/mojo/ArkPluginMojoTest.java
@@ -103,20 +103,24 @@ public class ArkPluginMojoTest {
         artifacts.add(new DefaultArtifact("groupyxx", "art1", "version", "provided", "jar", "17",
             new DefaultArtifactHandler()));
 
-        defaultArtifact = new DefaultArtifact("a", "b", "c", "compile", "jar", null,
-            new DefaultArtifactHandler());
-        defaultArtifact.setFile(new File("src/test/resources/test-demo.jar"));
-        artifacts.add(defaultArtifact);
+        DefaultArtifact shadeArtifact = new DefaultArtifact("shadeGroup", "shadeArtifact",
+            "shadeVersion", "provided", "jar", "shadeClassifier", new DefaultArtifactHandler());
+        shadeArtifact.setFile(new File("src/test/resources/test-demo.jar"));
+        artifacts.add(shadeArtifact);
+
+        DefaultArtifact projectArtifact = new DefaultArtifact("a", "b", "c", "compile", "jar",
+            null, new DefaultArtifactHandler());
+        projectArtifact.setFile(new File("src/test/resources/test-demo.jar"));
 
         Build build = new Build();
         build.setOutputDirectory("./notexist");
         MavenProject mavenProject = mock(MavenProject.class);
         when(mavenProject.getArtifacts()).thenReturn(artifacts);
-        when(mavenProject.getArtifact()).thenReturn(defaultArtifact);
+        when(mavenProject.getArtifact()).thenReturn(projectArtifact);
         when(mavenProject.getBuild()).thenReturn(build);
         arkPluginMojo.setProject(mavenProject);
         arkPluginMojo.setShades(new LinkedHashSet<>(Collections
-            .singleton("com.alipay.sofa:test-demo:1.0.0")));
+            .singleton("shadeGroup:shadeArtifact:shadeVersion:shadeClassifier")));
 
         field = ArkPluginMojo.class.getDeclaredField("attach");
         field.setAccessible(true);
@@ -131,7 +135,7 @@ public class ArkPluginMojoTest {
         arkPluginMojo.workDirectory = new File("./");
         arkPluginMojo.exportPluginClass = true;
         arkPluginMojo.execute();
-        assertEquals(6, finalResourcesCountInJar.get());
+        assertEquals(4, finalResourcesCountInJar.get());
     }
 
     @Test


### PR DESCRIPTION
fix [issue-935](https://github.com/sofastack/sofa-ark/issues/935)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the artifact handling in the archiver to avoid adding conflicting project artifacts.
  - Updated artifact declarations and settings to ensure proper handling and cleanup in test cases.

- **Refactor**
  - Simplified artifact conditions and dependency checks for more efficient processing in the build plugin.

- **Tests**
  - Adjusted test cases to reflect changes in artifact handling and ensure accurate validation of resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->