### PR TITLE
warn when mark and delete biz temp work failed

### DIFF
--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
@@ -553,8 +553,9 @@ public class BizModel implements Biz {
         }
 
         if (bizTempWorkDir.isDirectory()) {
+            String newPath = "";
             try {
-                String newPath = markBizTempWorkDirRecycled(bizTempWorkDir);
+                newPath = markBizTempWorkDirRecycled(bizTempWorkDir);
                 File markedFile = new File(newPath);
                 if (!markedFile.exists()) {
                     ArkLoggerFactory.getDefaultLogger().warn(
@@ -565,8 +566,9 @@ public class BizModel implements Biz {
 
                 return deleteQuietly(markedFile);
             } catch (IOException e) {
-                throw new ArkRuntimeException("mark and delete biz temp work dir error: "
-                                              + e.getMessage());
+                ArkLoggerFactory.getDefaultLogger().warn(
+                    "mark and delete biz temp work dir error:" + e.getMessage());
+                return false;
             }
 
         }

--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/model/BizState.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/model/BizState.java
@@ -23,9 +23,29 @@ package com.alipay.sofa.ark.spi.model;
  * @since 0.4.0
  */
 public enum BizState {
-    UNRESOLVED("unresolved"), RESOLVED("resolved"), ACTIVATED("activated"), DEACTIVATED(
-                                                                                        "deactivated"), BROKEN(
-                                                                                                               "broken");
+    /**
+     * install not started yet
+     */
+    UNRESOLVED("unresolved"),
+    /**
+     * installing
+     */
+    RESOLVED("resolved"),
+
+    /**
+     * install succeed, and start serving
+     */
+    ACTIVATED("activated"),
+
+    /**
+     * uninstall
+     */
+    DEACTIVATED("deactivated"),
+
+    /**
+     * install failed.
+     */
+    BROKEN("broken");
 
     private String state;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
    - Improved exception handling in the `recycleBizTempWorkDir` method to log a warning message and return `false` instead of throwing an exception.

- **Documentation**
    - Added detailed comments to the `BizState` enum to clarify the states for each enum constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->