### PR TITLE
close the biz classloader

### DIFF
--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
@@ -386,6 +386,15 @@ public class BizModel implements Biz {
             denyImportPackages = null;
             denyImportClasses = null;
             denyImportResources = null;
+            // close classloader
+            if (classLoader instanceof AbstractClasspathClassLoader) {
+                try {
+                    ((AbstractClasspathClassLoader) classLoader).close();
+                } catch (IOException e) {
+                    ArkLoggerFactory.getDefaultLogger().warn(
+                        "Ark biz {} close biz classloader fail", getIdentity());
+                }
+            }
             recycleBizTempWorkDir(bizTempWorkDir);
             bizTempWorkDir = null;
             if (classLoader instanceof AbstractClasspathClassLoader) {

--- a/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/api/ArkClientTest.java
+++ b/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/api/ArkClientTest.java
@@ -231,6 +231,20 @@ public class ArkClientTest extends BaseTest {
     }
 
     @Test
+    public void testUninstallBizWhenIncludeLib() throws Throwable {
+
+        testCheckBiz();
+        // test uninstall biz
+        ClientResponse response = uninstallBiz("biz-demo", "3.0.0");
+        assertEquals(SUCCESS, response.getCode());
+
+        // test check all biz
+        response = checkBiz();
+        assertEquals(SUCCESS, response.getCode());
+        assertEquals(2, response.getBizInfos().size());
+    }
+
+    @Test
     public void testInstallBizWithThrowable() throws Throwable {
 
         File bizFile = createBizSaveFile("biz-demo", "1.0.0");


### PR DESCRIPTION
### Motivation

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.
标记文件夹被回收时，资源被占用导致失败问题修复

### Modification

Describe the idea and modifications you've done.
由于Classloader加载了lib包下的jar包未释放，所以关闭Classloader后，标记文件夹回收时即可正常执行


### Result

Resolved or fixed #<GitHub issue number>. 
[262](https://github.com/koupleless/koupleless/issues/262)

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the cleanup process by ensuring the classloader is properly closed when stopping the business model.

- **Tests**
  - Added a new test to verify the uninstallation of a business artifact, including its library dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->