### PR TITLE
目前 system scope 被当成 provided 

### DIFF
--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ArtifactsLibraries.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ArtifactsLibraries.java
@@ -44,7 +44,7 @@ public class ArtifactsLibraries implements Libraries {
         libraryScopes.put(Artifact.SCOPE_COMPILE, LibraryScope.COMPILE);
         libraryScopes.put(Artifact.SCOPE_RUNTIME, LibraryScope.RUNTIME);
         libraryScopes.put(Artifact.SCOPE_PROVIDED, LibraryScope.PROVIDED);
-        libraryScopes.put(Artifact.SCOPE_SYSTEM, LibraryScope.PROVIDED);
+        libraryScopes.put(Artifact.SCOPE_SYSTEM, LibraryScope.COMPILE);
         SCOPES = Collections.unmodifiableMap(libraryScopes);
     }
 


### PR DESCRIPTION
某些情况下第三方依赖会当成本地 jar 被依赖进项目，这种依赖在模块打包时不会被带进模块中
`
<dependency>
          <groupId>com.xxx</groupId>
          <artifactId>api-lib</artifactId>
          <version>1.0.0</version>
          <scope>system</scope>
          <systemPath>${basedir}/lib/api-lib-1.0.0.jar</systemPath>
</dependency>
`


fix https://github.com/koupleless/koupleless/issues/169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the library scope mapping to improve dependency resolution, classifying `Artifact.SCOPE_SYSTEM` as a compile-time library.

- **Bug Fixes**
	- Adjusted the handling of library scopes to enhance the build process and runtime behavior of applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->