### PR TITLE
增加declared白名单

### DIFF
--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/constant/Constants.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/constant/Constants.java
@@ -254,7 +254,7 @@ public class Constants {
     public final static String       EXTENSION_INCLUDES_GROUPIDS                   = "includeGroupIds";
     public final static String       EXTENSION_INCLUDES_ARTIFACTIDS                = "includeArtifactIds";
 
-    public final static String       DECLARED_ARTIFACT_IDS                         = "declaredArtifactIds";
+    public final static String       DECLARED_LIBRARIES_WHITELIST                  = "declared.libraries.whitelist";
 
     public static final List<String> CHANNEL_QUIT                                  = new ArrayList<>();
 

--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/constant/Constants.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/constant/Constants.java
@@ -254,6 +254,8 @@ public class Constants {
     public final static String       EXTENSION_INCLUDES_GROUPIDS                   = "includeGroupIds";
     public final static String       EXTENSION_INCLUDES_ARTIFACTIDS                = "includeArtifactIds";
 
+    public final static String       DECLARED_ARTIFACT_IDS                         = "declaredArtifactIds";
+
     public static final List<String> CHANNEL_QUIT                                  = new ArrayList<>();
 
     static {

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.ark.boot.mojo;
 
+import com.alipay.sofa.ark.boot.mojo.model.ArkConfigHolder;
 import com.alipay.sofa.ark.tools.ArtifactItem;
 import com.alipay.sofa.ark.tools.Libraries;
 import com.alipay.sofa.ark.tools.Repackager;
@@ -56,10 +57,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static com.alipay.sofa.ark.boot.mojo.utils.ParseUtils.getStringSet;
+import static com.alipay.sofa.ark.spi.constant.Constants.DECLARED_ARTIFACT_IDS;
 
 /**
  * Repackages existing JAR archives so that they can be executed from the command
@@ -363,7 +368,7 @@ public class RepackageMojo extends TreeMojo {
                 } else {
                     artifactItems = getAllArtifactByMavenTree();
                 }
-                repackager.prepareDeclaredLibraries(artifactItems);
+                repackager.prepareDeclaredLibraries(artifactItems, getDeclaredArtifactIds());
             }
             MavenProject rootProject = MavenUtils.getRootProject(this.mavenProject);
             repackager.setGitDirectory(getGitDirectory(rootProject));
@@ -372,6 +377,15 @@ public class RepackageMojo extends TreeMojo {
             throw new MojoExecutionException(ex.getMessage(), ex);
         }
         updateArtifact(appTarget, repackager.getModuleTargetFile());
+    }
+
+    protected Set<String> getDeclaredArtifactIds() throws IOException {
+        Set<String> res = new HashSet<>();
+        Properties prop = ArkConfigHolder.getArkProperties(baseDir.getAbsolutePath());
+        Map<String, Object> arkYaml = ArkConfigHolder.getArkYaml(baseDir.getAbsolutePath());
+        res.addAll(getStringSet(prop, DECLARED_ARTIFACT_IDS));
+        res.addAll(getStringSet(arkYaml, DECLARED_ARTIFACT_IDS));
+        return res;
     }
 
     private File getGitDirectory(MavenProject rootProject) {

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/utils/ParseUtils.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/utils/ParseUtils.java
@@ -16,8 +16,10 @@
  */
 package com.alipay.sofa.ark.boot.mojo.utils;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -40,9 +42,29 @@ public class ParseUtils {
     }
 
     public static Set<String> getStringSet(Map<String, Object> yaml, String confKey) {
-        if (null != yaml && yaml.containsKey(confKey) && null != yaml.get(confKey)) {
-            return newHashSet((List<String>) yaml.get(confKey));
+        Object value = getValue(yaml, confKey);
+        if (null == value) {
+            return newHashSet();
         }
-        return newHashSet();
+        return newHashSet((List<String>) value);
+    }
+
+    private static Object getValue(Map<String, Object> yaml, String confKey) {
+        if (MapUtils.isEmpty(yaml) || StringUtils.isEmpty(confKey)) {
+            return null;
+        }
+
+        List<String> keys = Arrays.asList(StringUtils.split(confKey, "."));
+        String currentKey = keys.get(0);
+        if (yaml.containsKey(currentKey) && null != yaml.get(currentKey) && keys.size() == 1) {
+            return yaml.get(currentKey);
+        }
+
+        if (yaml.containsKey(currentKey) && null != yaml.get(currentKey) && keys.size() > 1
+            && yaml.get(currentKey) instanceof Map) {
+            return getValue((Map<String, Object>) yaml.get(currentKey),
+                StringUtils.join(keys.subList(1, keys.size()), "."));
+        }
+        return null;
     }
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/CommonUtils.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/CommonUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.boot.mojo;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: CommonUtils.java, v 0.1 2024年08月22日 21:56 立蓬 Exp $
+ */
+public class CommonUtils {
+
+    public static File getResourceFile(String resourceName) throws URISyntaxException {
+        URL url = CommonUtils.class.getClassLoader().getResource(resourceName);
+        return new File(url.toURI());
+    }
+}

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategyTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategyTest.java
@@ -229,11 +229,6 @@ public class ModuleSlimStrategyTest {
         strategy.logExcludeMessage(jarGroupIds, jarArtifactIds, jarList, artifacts, false);
     }
 
-    private File getResourceFile(String resourceName) throws URISyntaxException {
-        URL url = this.getClass().getClassLoader().getResource(resourceName);
-        return new File(url.toURI());
-    }
-
     private MavenProject getMockBootstrapProject() throws URISyntaxException {
         MavenProject project = new MavenProject();
         project.setArtifactId("base-bootstrap");
@@ -250,7 +245,7 @@ public class ModuleSlimStrategyTest {
 
         project.setParent(getRootProject());
 
-        setField("basedir", project, getResourceFile("baseDir"));
+        setField("basedir", project, CommonUtils.getResourceFile("baseDir"));
         return project;
     }
 
@@ -297,6 +292,6 @@ public class ModuleSlimStrategyTest {
     }
 
     private File mockBaseDir() throws URISyntaxException {
-        return getResourceFile("baseDir");
+        return CommonUtils.getResourceFile("baseDir");
     }
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
@@ -45,23 +45,21 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static com.alipay.sofa.ark.boot.mojo.RepackageMojo.ArkConstants.getClassifier;
 import static java.lang.System.clearProperty;
 import static java.lang.System.setProperty;
-import static java.util.Arrays.asList;
 import static org.apache.commons.beanutils.BeanUtils.copyProperties;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -412,5 +410,18 @@ public class RepackageMojoTest {
         copyProperties(new ExcludeConfig(), new ExcludeConfig());
         copyProperties(new ExcludeConfigResponse(), new ExcludeConfigResponse());
         assertEquals("", getClassifier());
+    }
+
+    @Test
+    public void testGetDeclaredLibrariesWhiteList() throws URISyntaxException, IOException {
+        RepackageMojo repackageMojo = new RepackageMojo();
+        ReflectionUtils.setField("declaredMode", repackageMojo, true);
+        ReflectionUtils.setField("baseDir", repackageMojo, CommonUtils.getResourceFile("baseDir"));
+
+        Set<String> whitelist = repackageMojo.getDeclaredArtifactIds();
+        assertTrue(whitelist.contains("ark-common-yml"));
+        assertTrue(whitelist.contains("biz-common-yml"));
+        assertTrue(whitelist.contains("biz-common"));
+        assertTrue(whitelist.contains("ark-common"));
     }
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
@@ -56,6 +56,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.alipay.sofa.ark.boot.mojo.RepackageMojo.ArkConstants.getClassifier;
 import static java.lang.System.clearProperty;
@@ -418,10 +419,12 @@ public class RepackageMojoTest {
         ReflectionUtils.setField("declaredMode", repackageMojo, true);
         ReflectionUtils.setField("baseDir", repackageMojo, CommonUtils.getResourceFile("baseDir"));
 
-        Set<String> whitelist = repackageMojo.getDeclaredLibrariesWhitelist();
-        assertTrue(whitelist.contains("ark-common-yml"));
-        assertTrue(whitelist.contains("biz-common-yml"));
-        assertTrue(whitelist.contains("biz-common"));
-        assertTrue(whitelist.contains("ark-common"));
+        Set<ArtifactItem> whitelist = repackageMojo.getDeclaredLibrariesWhitelist();
+
+        Set<String> res = whitelist.stream().map(it->it.getGroupId()+":"+it.getArtifactId()).collect(Collectors.toSet());
+        assertTrue(res.contains("com.ark.yml:ark-common-yml"));
+        assertTrue(res.contains("com.biz.yml:biz-common-yml"));
+        assertTrue(res.contains("com.biz:biz-common"));
+        assertTrue(res.contains("com.ark:ark-common"));
     }
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
@@ -418,7 +418,7 @@ public class RepackageMojoTest {
         ReflectionUtils.setField("declaredMode", repackageMojo, true);
         ReflectionUtils.setField("baseDir", repackageMojo, CommonUtils.getResourceFile("baseDir"));
 
-        Set<String> whitelist = repackageMojo.getDeclaredArtifactIds();
+        Set<String> whitelist = repackageMojo.getDeclaredLibrariesWhitelist();
         assertTrue(whitelist.contains("ark-common-yml"));
         assertTrue(whitelist.contains("biz-common-yml"));
         assertTrue(whitelist.contains("biz-common"));

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/utils/ParseUtilsTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/utils/ParseUtilsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.boot.mojo.utils;
+
+import com.alipay.sofa.ark.boot.mojo.CommonUtils;
+import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Set;
+
+import static com.alipay.sofa.ark.spi.constant.Constants.DECLARED_LIBRARIES_WHITELIST;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: ParseUtilsTest.java, v 0.1 2024年08月23日 10:55 立蓬 Exp $
+ */
+public class ParseUtilsTest {
+    @Test
+    public void testGetStringSetForYaml() throws URISyntaxException {
+        Map<String, Object> yml = (Map<String, Object>) loadYaml();
+        Set<String> excludes = ParseUtils.getStringSet(yml, "excludes");
+        Set<String> whitelist = ParseUtils.getStringSet(yml, DECLARED_LIBRARIES_WHITELIST);
+
+        assertTrue(excludes.contains("org.apache.commons:commons-lang3-yml"));
+        assertTrue(excludes.contains("commons-beanutils:commons-beanutils-yml"));
+
+        assertTrue(whitelist.contains("com.biz.yml:biz-common-yml"));
+        assertTrue(whitelist.contains("com.ark.yml:ark-common-yml"));
+    }
+
+    private Object loadYaml() throws URISyntaxException {
+        File yml = CommonUtils.getResourceFile("baseDir/conf/ark/bootstrap.yml");
+        try (FileInputStream fis = new FileInputStream(yml)) {
+            Yaml yaml = new Yaml();
+            return yaml.load(fis);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/resources/baseDir/conf/ark/bootstrap.properties
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/resources/baseDir/conf/ark/bootstrap.properties
@@ -5,5 +5,5 @@ excludeGroupIds=org.springframework
 # excludeArtifactIds config ${artifactId}, split by ','
 excludeArtifactIds=sofa-ark-spi
 
-# declared artifactIds config ${artifactId}, split by ','
-declaredArtifactIds=ark-common,biz-common
+# declared libraries whitelist config {groupId:artifactId}, split by ','
+declared.libraries.whitelist=com.ark:ark-common,com.biz:biz-common

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/resources/baseDir/conf/ark/bootstrap.properties
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/resources/baseDir/conf/ark/bootstrap.properties
@@ -1,6 +1,9 @@
-# excludes config groupId:artifactId} {groupId:artifactId:version} or {groupId:artifactId:version:classifier}, split by ','
+# excludes config {groupId:artifactId} {groupId:artifactId:version} or {groupId:artifactId:version:classifier}, split by ','
 excludes=org.apache.commons:commons-lang3,commons-beanutils:commons-beanutils
 # excludeGroupIds config ${groupId}, split by ','
 excludeGroupIds=org.springframework
 # excludeArtifactIds config ${artifactId}, split by ','
 excludeArtifactIds=sofa-ark-spi
+
+# declared artifactIds config ${artifactId}, split by ','
+declaredArtifactIds=ark-common,biz-common

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/resources/baseDir/conf/ark/bootstrap.yml
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/resources/baseDir/conf/ark/bootstrap.yml
@@ -8,3 +8,9 @@ excludeGroupIds:
   - org.springframework-yml
 excludeArtifactIds:
   - sofa-ark-spi-yml
+
+# declaredArtifactIds 中配置 ${artifactId}, 不同依赖以 - 隔开
+
+declaredArtifactIds:
+  - ark-common-yml
+  - biz-common-yml

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/resources/baseDir/conf/ark/bootstrap.yml
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/resources/baseDir/conf/ark/bootstrap.yml
@@ -11,6 +11,8 @@ excludeArtifactIds:
 
 # declaredArtifactIds 中配置 ${artifactId}, 不同依赖以 - 隔开
 
-declaredArtifactIds:
-  - ark-common-yml
-  - biz-common-yml
+declared:
+  libraries:
+    whitelist:
+      - com.ark.yml:ark-common-yml
+      - com.biz.yml:biz-common-yml

--- a/sofa-ark-parent/support/ark-tools/src/main/java/com/alipay/sofa/ark/tools/Repackager.java
+++ b/sofa-ark-parent/support/ark-tools/src/main/java/com/alipay/sofa/ark/tools/Repackager.java
@@ -195,7 +195,8 @@ public class Repackager {
         this.gitDirectory = gitDirectory;
     }
 
-    public void prepareDeclaredLibraries(Collection<ArtifactItem> artifactItems) {
+    public void prepareDeclaredLibraries(Collection<ArtifactItem> artifactItems,
+                                         Set<String> declaredArtifactIds) {
         if (!this.declaredMode) {
             return;
         }
@@ -207,6 +208,8 @@ public class Repackager {
                 declaredLibraries.add(artifactItem.getArtifactId());
             }
         }
+
+        declaredLibraries.addAll(declaredArtifactIds);
     }
 
     /**

--- a/sofa-ark-parent/support/ark-tools/src/main/java/com/alipay/sofa/ark/tools/Repackager.java
+++ b/sofa-ark-parent/support/ark-tools/src/main/java/com/alipay/sofa/ark/tools/Repackager.java
@@ -195,8 +195,7 @@ public class Repackager {
         this.gitDirectory = gitDirectory;
     }
 
-    public void prepareDeclaredLibraries(Collection<ArtifactItem> artifactItems,
-                                         Set<String> declaredArtifactIds) {
+    public void prepareDeclaredLibraries(Collection<ArtifactItem> artifactItems) {
         if (!this.declaredMode) {
             return;
         }
@@ -208,8 +207,6 @@ public class Repackager {
                 declaredLibraries.add(artifactItem.getArtifactId());
             }
         }
-
-        declaredLibraries.addAll(declaredArtifactIds);
     }
 
     /**

--- a/sofa-ark-parent/support/ark-tools/src/test/java/com/alipay/sofa/ark/tools/RepackagerTest.java
+++ b/sofa-ark-parent/support/ark-tools/src/test/java/com/alipay/sofa/ark/tools/RepackagerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.jar.JarEntry;
@@ -124,17 +125,17 @@ public class RepackagerTest {
     @Test
     public void testPrepareDeclaredLibraries() throws Exception {
 
-        repackager.prepareDeclaredLibraries(null);
+        repackager.prepareDeclaredLibraries(null, Collections.emptySet());
         repackager.setDeclaredMode(true);
-        repackager.prepareDeclaredLibraries(null);
+        repackager.prepareDeclaredLibraries(null, Collections.emptySet());
 
         ArtifactItem artifactItem = new ArtifactItem();
         artifactItem.setArtifactId("x");
-        repackager.prepareDeclaredLibraries(newArrayList(artifactItem));
+        repackager.prepareDeclaredLibraries(newArrayList(artifactItem), newHashSet("y"));
 
         Field field = Repackager.class.getDeclaredField("declaredLibraries");
         field.setAccessible(true);
-        assertEquals(newHashSet("x"), field.get(repackager));
+        assertEquals(newHashSet("x", "y"), field.get(repackager));
     }
 
     @Test

--- a/sofa-ark-parent/support/ark-tools/src/test/java/com/alipay/sofa/ark/tools/RepackagerTest.java
+++ b/sofa-ark-parent/support/ark-tools/src/test/java/com/alipay/sofa/ark/tools/RepackagerTest.java
@@ -125,17 +125,17 @@ public class RepackagerTest {
     @Test
     public void testPrepareDeclaredLibraries() throws Exception {
 
-        repackager.prepareDeclaredLibraries(null, Collections.emptySet());
+        repackager.prepareDeclaredLibraries(null);
         repackager.setDeclaredMode(true);
-        repackager.prepareDeclaredLibraries(null, Collections.emptySet());
+        repackager.prepareDeclaredLibraries(null);
 
         ArtifactItem artifactItem = new ArtifactItem();
         artifactItem.setArtifactId("x");
-        repackager.prepareDeclaredLibraries(newArrayList(artifactItem), newHashSet("y"));
+        repackager.prepareDeclaredLibraries(newArrayList(artifactItem));
 
         Field field = Repackager.class.getDeclaredField("declaredLibraries");
         field.setAccessible(true);
-        assertEquals(newHashSet("x", "y"), field.get(repackager));
+        assertEquals(newHashSet("x"), field.get(repackager));
     }
 
     @Test


### PR DESCRIPTION
fix https://github.com/koupleless/koupleless/issues/245

使用方式，在以下任意一处添加 declared.libraries.whitelist ，格式为 {groupId:artifactId}，并以 ',' 隔开：

1. “模块项目根目录/conf/ark/bootstrap.properties”，比如：my-module/conf/ark/bootstrap.properties

```
# declared libraries whitelist config {groupId:artifactId}, split by ','
declared.libraries.whitelist=com.ark:ark-common,com.biz:biz-common
```

2. “模块项目根目录/conf/ark/bootstrap.yml”，比如：my-module/conf/ark/bootstrap.yml

```
# declaredArtifactIds 中配置 ${artifactId}, 不同依赖以 - 隔开

declared:
  libraries:
    whitelist:
      - com.ark.yml:ark-common-yml
```


### Motivation

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification

Describe the idea and modifications you've done.

### Result

Resolved or fixed #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced constants for declared artifact IDs and libraries whitelist to enhance configurability.
  - Added methods to retrieve declared artifact IDs and libraries whitelist from configuration, improving repackaging functionality.
  - Enhanced configuration files with new entries for declared artifact IDs and libraries, allowing for better artifact management.

- **Bug Fixes**
  - Updated test methods to reflect changes in method signatures, enhancing test reliability.

- **Documentation**
  - Improved comments in configuration files for better readability and usability.

- **Tests**
  - Added new tests to validate the functionality of the recently introduced methods, increasing test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->