### PR TITLE
feat:baseDependencyParentIdentity_without_version

### DIFF
--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategy.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategy.java
@@ -131,10 +131,12 @@ public class ModuleSlimStrategy {
         return artifacts.stream().filter(it -> dependencyIdentities.contains(getArtifactIdentity(it))).collect(Collectors.toSet());
     }
 
-    private Model getBaseDependencyParentOriginalModel() {
+    protected Model getBaseDependencyParentOriginalModel() {
         MavenProject proj = project;
         while (null != proj) {
-            if (getGAVIdentity(proj.getArtifact()).equals(config.getBaseDependencyParentIdentity())) {
+            if (getGAIdentity(proj.getArtifact()).equals(config.getBaseDependencyParentIdentity())
+                || getGAVIdentity(proj.getArtifact()).equals(
+                    config.getBaseDependencyParentIdentity())) {
                 return proj.getOriginalModel();
             }
             proj = proj.getParent();
@@ -145,6 +147,10 @@ public class ModuleSlimStrategy {
     private String getGAVIdentity(Artifact artifact) {
         return artifact.getGroupId() + STRING_COLON + artifact.getArtifactId() + STRING_COLON
                + artifact.getBaseVersion();
+    }
+
+    private String getGAIdentity(Artifact artifact) {
+        return artifact.getGroupId() + STRING_COLON + artifact.getArtifactId();
     }
 
     protected String getArtifactIdentity(Artifact artifact) {

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategyTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategyTest.java
@@ -46,6 +46,7 @@ import static com.alipay.sofa.ark.boot.mojo.ReflectionUtils.setField;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -134,6 +135,20 @@ public class ModuleSlimStrategyTest {
             sameArtifact, differenceArtifact));
         assertTrue(res.contains(sameArtifact));
         assertFalse(res.contains(differenceArtifact));
+    }
+
+    @Test
+    public void testGetBaseDependencyParentOriginalModel() throws URISyntaxException {
+        // find base-dependency-parent by gav identity
+        ModuleSlimConfig config = (new ModuleSlimConfig())
+            .setBaseDependencyParentIdentity("com.mock:base-dependencies-starter:1.0");
+        ModuleSlimStrategy strategy = new ModuleSlimStrategy(getMockBootstrapProject(), null,
+            config, mockBaseDir(), null);
+        assertNotNull(strategy.getBaseDependencyParentOriginalModel());
+
+        // find base-dependency-parent by ga identity
+        config.setBaseDependencyParentIdentity("com.mock:base-dependencies-starter");
+        assertNotNull(strategy.getBaseDependencyParentOriginalModel());
     }
 
     @Test


### PR DESCRIPTION
允许 baseDependencyParentIdentity 不配置 version，只配置 ${groupId}:${artifactId}，简化用户配置

### Motivation

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification

Describe the idea and modifications you've done.

### Result

Resolved or fixed #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced method accessibility for subclasses to retrieve the base dependency parent model.
	- Introduced a new method to construct artifact identity strings without versioning.

- **Tests**
	- Added a test to verify the functionality of retrieving the base dependency parent model using different identity formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->