### PR TITLE
修复静态合并部署时，springcloud依赖兼容性问题导致模块先于基座被加载的问题(#1032)

### DIFF
--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.ark.springboot.listener;
 
 import com.alipay.sofa.ark.api.ArkConfigs;
 import com.alipay.sofa.ark.support.startup.EmbedSofaArkBootstrap;
+import org.springframework.boot.web.context.ConfigurableWebServerApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ApplicationContextEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -33,7 +34,8 @@ public class ArkDeployStaticBizListener implements ApplicationListener<Applicati
             return;
         }
         if (ArkConfigs.isEmbedEnable() && ArkConfigs.isEmbedStaticBizEnable()) {
-            if (event instanceof ContextRefreshedEvent) {
+            if (event instanceof ContextRefreshedEvent
+                && event.getApplicationContext() instanceof ConfigurableWebServerApplicationContext) {
                 // After the master biz is started, statically deploy the other biz from classpath
                 EmbedSofaArkBootstrap.deployStaticBizAfterEmbedMasterBizStarted();
             }


### PR DESCRIPTION
issue: https://github.com/sofastack/sofa-ark/issues/1032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the deployment logic for static business processes to ensure they only occur under specific conditions, enhancing application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->