### PR TITLE
add param to determine whether unpack biz when install (#325)

### DIFF
--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceImpl.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceImpl.java
@@ -52,19 +52,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.jar.Attributes;
 
-import static com.alipay.sofa.ark.spi.constant.Constants.ARK_BIZ_NAME;
-import static com.alipay.sofa.ark.spi.constant.Constants.ARK_BIZ_VERSION;
-import static com.alipay.sofa.ark.spi.constant.Constants.DENY_IMPORT_CLASSES;
-import static com.alipay.sofa.ark.spi.constant.Constants.DENY_IMPORT_PACKAGES;
-import static com.alipay.sofa.ark.spi.constant.Constants.DENY_IMPORT_RESOURCES;
-import static com.alipay.sofa.ark.spi.constant.Constants.INJECT_EXPORT_PACKAGES;
-import static com.alipay.sofa.ark.spi.constant.Constants.INJECT_PLUGIN_DEPENDENCIES;
-import static com.alipay.sofa.ark.spi.constant.Constants.MAIN_CLASS_ATTRIBUTE;
-import static com.alipay.sofa.ark.spi.constant.Constants.MASTER_BIZ;
-import static com.alipay.sofa.ark.spi.constant.Constants.PRIORITY_ATTRIBUTE;
-import static com.alipay.sofa.ark.spi.constant.Constants.START_CLASS_ATTRIBUTE;
-import static com.alipay.sofa.ark.spi.constant.Constants.WEB_CONTEXT_PATH;
-import static com.alipay.sofa.ark.spi.constant.Constants.DECLARED_LIBRARIES;
+import static com.alipay.sofa.ark.spi.constant.Constants.*;
 
 /**
  * {@link BizFactoryService}
@@ -116,7 +104,9 @@ public class BizFactoryServiceImpl implements BizFactoryService {
     @Override
     public Biz createBiz(File file) throws IOException {
         BizArchive bizArchive;
-        if (ArkConfigs.isEmbedEnable()) {
+        boolean unpackBizWhenInstall = Boolean.parseBoolean(ArkConfigs.getStringValue(
+                UNPACK_BIZ_WHEN_INSTALL, "true"));
+        if (ArkConfigs.isEmbedEnable() && unpackBizWhenInstall) {
             File unpackFile = FileUtils.file(file.getAbsolutePath() + "-unpack");
             if (!unpackFile.exists()) {
                 unpackFile = FileUtils.unzip(file, file.getAbsolutePath() + "-unpack");

--- a/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceTest.java
+++ b/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceTest.java
@@ -33,8 +33,7 @@ import java.net.URL;
 
 import static com.alipay.sofa.ark.api.ArkConfigs.putStringValue;
 import static com.alipay.sofa.ark.container.service.ArkServiceContainerHolder.getContainer;
-import static com.alipay.sofa.ark.spi.constant.Constants.ARK_PLUGIN_MARK_ENTRY;
-import static com.alipay.sofa.ark.spi.constant.Constants.MASTER_BIZ;
+import static com.alipay.sofa.ark.spi.constant.Constants.*;
 import static java.lang.Thread.currentThread;
 import static org.junit.Assert.assertNotNull;
 
@@ -80,6 +79,26 @@ public class BizFactoryServiceTest extends BaseTest {
         assertNotNull(masterBiz);
         assertNotNull(masterBiz.getBizClassLoader().getResource(
             "com/alipay/sofa/ark/container/service/biz/"));
+    }
+
+    @Test
+    public void testCreateBizWithoutBizOperationUnpack() throws IOException {
+        ClassLoader cl = currentThread().getContextClassLoader();
+        URL sampleBiz = cl.getResource("sample-biz.jar");
+        System.setProperty(EMBED_ENABLE, "true");
+        System.setProperty(UNPACK_BIZ_WHEN_INSTALL, "true");
+        Biz bizUnpack = bizFactoryService.createBiz(FileUtils.file(sampleBiz.getFile()));
+        assertNotNull(bizUnpack);
+    }
+
+    @Test
+    public void testCreateBizWithoutBizOperation() throws IOException {
+        ClassLoader cl = currentThread().getContextClassLoader();
+        URL sampleBiz = cl.getResource("sample-biz.jar");
+        System.setProperty(EMBED_ENABLE, "true");
+        System.setProperty(UNPACK_BIZ_WHEN_INSTALL, "false");
+        Biz biz = bizFactoryService.createBiz(FileUtils.file(sampleBiz.getFile()));
+        assertNotNull(biz);
     }
 
     @Test

--- a/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceTest.java
+++ b/sofa-ark-parent/core-impl/container/src/test/java/com/alipay/sofa/ark/container/service/biz/BizFactoryServiceTest.java
@@ -34,6 +34,7 @@ import java.net.URL;
 import static com.alipay.sofa.ark.api.ArkConfigs.putStringValue;
 import static com.alipay.sofa.ark.container.service.ArkServiceContainerHolder.getContainer;
 import static com.alipay.sofa.ark.spi.constant.Constants.*;
+import static com.alipay.sofa.ark.spi.constant.Constants.UNPACK_BIZ_WHEN_INSTALL;
 import static java.lang.Thread.currentThread;
 import static org.junit.Assert.assertNotNull;
 
@@ -82,23 +83,33 @@ public class BizFactoryServiceTest extends BaseTest {
     }
 
     @Test
-    public void testCreateBizWithoutBizOperationUnpack() throws IOException {
-        ClassLoader cl = currentThread().getContextClassLoader();
-        URL sampleBiz = cl.getResource("sample-biz.jar");
-        System.setProperty(EMBED_ENABLE, "true");
-        System.setProperty(UNPACK_BIZ_WHEN_INSTALL, "true");
-        Biz bizUnpack = bizFactoryService.createBiz(FileUtils.file(sampleBiz.getFile()));
-        assertNotNull(bizUnpack);
-    }
-
-    @Test
     public void testCreateBizWithoutBizOperation() throws IOException {
-        ClassLoader cl = currentThread().getContextClassLoader();
-        URL sampleBiz = cl.getResource("sample-biz.jar");
-        System.setProperty(EMBED_ENABLE, "true");
-        System.setProperty(UNPACK_BIZ_WHEN_INSTALL, "false");
-        Biz biz = bizFactoryService.createBiz(FileUtils.file(sampleBiz.getFile()));
-        assertNotNull(biz);
+        String originalEmbed = System.getProperty(EMBED_ENABLE);
+        String originalUnpack = System.getProperty(UNPACK_BIZ_WHEN_INSTALL);
+        try {
+            ClassLoader cl = currentThread().getContextClassLoader();
+            URL sampleBiz = cl.getResource("sample-biz.jar");
+            System.setProperty(EMBED_ENABLE, "true");
+            System.setProperty(UNPACK_BIZ_WHEN_INSTALL, "true");
+            Biz bizUnpack = bizFactoryService.createBiz(FileUtils.file(sampleBiz.getFile()));
+            assertNotNull(bizUnpack);
+
+            System.setProperty(UNPACK_BIZ_WHEN_INSTALL, "false");
+            Biz biz = bizFactoryService.createBiz(FileUtils.file(sampleBiz.getFile()));
+            assertNotNull(biz);
+
+        } finally {
+            if (originalEmbed != null) {
+                System.setProperty(EMBED_ENABLE, originalEmbed);
+            } else {
+                System.clearProperty(EMBED_ENABLE);
+            }
+            if (originalUnpack != null) {
+                System.setProperty(UNPACK_BIZ_WHEN_INSTALL, originalUnpack);
+            } else {
+                System.clearProperty(UNPACK_BIZ_WHEN_INSTALL);
+            }
+        }
     }
 
     @Test

--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/constant/Constants.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/constant/Constants.java
@@ -210,6 +210,11 @@ public class Constants {
     public final static String       AUTO_UNINSTALL_WHEN_FAILED_ENABLE             = "sofa.ark.auto.uninstall.when.failed.enable";
 
     /**
+     * unpack the biz when install
+     */
+    public final static String       UNPACK_BIZ_WHEN_INSTALL                       = "sofa.ark.unpack.biz.when.install";
+
+    /**
      * support multiple version biz as activated
      */
     public final static String       ACTIVATE_MULTI_BIZ_VERSION_ENABLE             = "sofa.ark.activate.multi.biz.version.enable";


### PR DESCRIPTION
### Motivation

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification

Describe the idea and modifications you've done.

### Result

Resolved or fixed #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for unpacking business archives during installation, enhancing flexibility.
	- Added a new constant for unpacking behavior to improve code clarity.

- **Bug Fixes**
	- Enhanced testing coverage for `createBiz` functionality with new test scenarios.

- **Documentation**
	- Added comments to clarify the purpose of new constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->