### PR TITLE
set logback context name=default

### DIFF
--- a/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/adapter/ArkLogbackContextSelector.java
+++ b/sofa-ark-parent/core/common/src/main/java/com/alipay/sofa/ark/common/adapter/ArkLogbackContextSelector.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.ark.common.adapter;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.selector.ContextSelector;
+import ch.qos.logback.core.CoreConstants;
 import com.alipay.sofa.ark.common.util.StringUtils;
 
 import java.util.HashMap;
@@ -82,7 +83,7 @@ public class ArkLogbackContextSelector implements ContextSelector {
                 loggerContext = CLASS_LOADER_LOGGER_CONTEXT.get(cls);
                 if (null == loggerContext) {
                     loggerContext = new LoggerContext();
-                    loggerContext.setName(Integer.toHexString(System.identityHashCode(cls)));
+                    loggerContext.setName(CoreConstants.DEFAULT_CONTEXT_NAME);
                     CLASS_LOADER_LOGGER_CONTEXT.put(cls, loggerContext);
                 }
             }

--- a/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/adapter/ArkLogbackContextSelectorTest.java
+++ b/sofa-ark-parent/core/common/src/test/java/com/alipay/sofa/ark/common/adapter/ArkLogbackContextSelectorTest.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.ClassicConstants;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.selector.ContextSelector;
 import ch.qos.logback.classic.util.ContextSelectorStaticBinder;
+import ch.qos.logback.core.CoreConstants;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.ILoggerFactory;
@@ -55,7 +56,7 @@ public class ArkLogbackContextSelectorTest {
 
         URL url = ArkLogbackContextSelectorTest.class.getClassLoader().getResource("");
         URLClassLoader loader = new URLClassLoader(new URL[] { url }, null);
-        String contextName = Integer.toHexString(System.identityHashCode(loader));
+        String contextName = CoreConstants.DEFAULT_CONTEXT_NAME;
 
         Method getContext = ArkLogbackContextSelector.class.getDeclaredMethod("getContext",
             ClassLoader.class);


### PR DESCRIPTION
fix https://github.com/sofastack/sofa-ark/issues/1043
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated logger context naming convention for standardization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->