### PR TITLE
fix: only_warning_when_building ark biz and excludding some jar not i…

### DIFF
--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategy.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategy.java
@@ -354,8 +354,11 @@ public class ModuleSlimStrategy {
 
         Set<Artifact> result = new HashSet<>();
         for (DependencyNode child : node.getChildren()) {
-            result.add(artifacts.get(getArtifactIdentity(child.getArtifact())));
-            result.addAll(getAllDependencies(child, artifacts));
+            String artifactId = getArtifactIdentity(child.getArtifact());
+            if (artifacts.containsKey(artifactId)) {
+                result.add(artifacts.get(artifactId));
+                result.addAll(getAllDependencies(child, artifacts));
+            }
         }
         return result;
     }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategy.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimStrategy.java
@@ -139,10 +139,6 @@ public class ModuleSlimStrategy {
                             getArtifactIdentity(artifact)));
         });
 
-        if(!excludedButNoDependencyInBase.isEmpty()){
-            throw new MojoExecutionException(String.format("check excludeWithBaseDependencyParentIdentity failed with base: %s",config.getBaseDependencyParentIdentity()));
-        }
-
         // The base contains this dependency, but the version and module are inconsistent; Please use the same dependency version as the base in the module.
         List<Dependency> baseDependencies = getAllBaseDependencies();
         Map<String,Dependency> baseDependencyIdentityWithoutVersion = baseDependencies.stream().collect(Collectors.toMap(MavenUtils::getDependencyIdentityWithoutVersion, it -> it));


### PR DESCRIPTION
当模块排除了基座里没有的包，打印 error 日志，但不阻断构建

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the handling of dependency exclusions, so build processes no longer fail abruptly when exclusions don’t match expected dependencies.
  - Enhanced dependency resolution by ensuring that only verified artifacts are processed, leading to smoother and more reliable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->