### PR TITLE
解决使用静态部署方案启动基座时，如果基座依赖了OpenFeign，会在基座refresh [context期间触发ContextRefreshedEvent，导致模块被提前部署，基座启动失败问题

### DIFF
--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
@@ -37,7 +37,7 @@ public class ArkDeployStaticBizListener implements ApplicationListener<Applicati
             return;
         }
         if (ArkConfigs.isEmbedEnable() && ArkConfigs.isEmbedStaticBizEnable()) {
-            if (event instanceof ContextRefreshedEvent && deployed.compareAndSet(false, true)) {
+            if (event instanceof ContextRefreshedEvent && deployed.compareAndSet(false, true) && event.getApplicationContext().getParent() == null) {
                 // After the master biz is started, statically deploy the other biz from classpath
                 EmbedSofaArkBootstrap.deployStaticBizAfterEmbedMasterBizStarted();
             }

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
@@ -37,8 +37,7 @@ public class ArkDeployStaticBizListener implements ApplicationListener<Applicati
             return;
         }
         if (ArkConfigs.isEmbedEnable() && ArkConfigs.isEmbedStaticBizEnable()) {
-            if (event instanceof ContextRefreshedEvent
-                && deployed.compareAndSet(false, true)
+            if (event instanceof ContextRefreshedEvent && deployed.compareAndSet(false, true)
                 && event.getApplicationContext().getParent() == null) {
                 // After the master biz is started, statically deploy the other biz from classpath
                 EmbedSofaArkBootstrap.deployStaticBizAfterEmbedMasterBizStarted();

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
@@ -37,7 +37,9 @@ public class ArkDeployStaticBizListener implements ApplicationListener<Applicati
             return;
         }
         if (ArkConfigs.isEmbedEnable() && ArkConfigs.isEmbedStaticBizEnable()) {
-            if (event instanceof ContextRefreshedEvent && deployed.compareAndSet(false, true) && event.getApplicationContext().getParent() == null) {
+            if (event instanceof ContextRefreshedEvent
+                && deployed.compareAndSet(false, true)
+                && event.getApplicationContext().getParent() == null) {
                 // After the master biz is started, statically deploy the other biz from classpath
                 EmbedSofaArkBootstrap.deployStaticBizAfterEmbedMasterBizStarted();
             }

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/test/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListenerTest.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/test/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListenerTest.java
@@ -75,9 +75,9 @@ public class ArkDeployStaticBizListenerTest {
         }
     }
 
-      /**
-     *  applicationEvent 不是 spring 根上下文的场景
-     */
+    /**
+    *  applicationEvent不是 spring 根上下文的场景
+    */
     @Test
     public void testNonSpringRootEvent() {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/test/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListenerTest.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/test/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListenerTest.java
@@ -74,6 +74,26 @@ public class ArkDeployStaticBizListenerTest {
         }
     }
 
+      /**
+     * applicationEvent 不是 spring 根上下文的场景
+     */
+    @Test
+    public void testNonSpringRootEvent() {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        try (MockedStatic<EmbedSofaArkBootstrap> bootstrap = mockStatic(EmbedSofaArkBootstrap.class);
+            MockedStatic<ArkConfigs> arkConfigs = mockStatic(ArkConfigs.class)) {
+            ClassLoader classLoader = ArkDeployStaticBizListener.class.getClassLoader();
+            Thread.currentThread().setContextClassLoader(classLoader);
+            arkConfigs.when(ArkConfigs::isEmbedEnable).thenReturn(true);
+            arkConfigs.when(ArkConfigs::isEmbedStaticBizEnable).thenReturn(true);
+            ArkDeployStaticBizListener listener = new ArkDeployStaticBizListener();
+            listener.onApplicationEvent(new ContextStartedEvent(new AnnotationConfigServletWebServerApplicationContext()));
+            bootstrap.verify(Mockito.times(0), EmbedSofaArkBootstrap::deployStaticBizAfterEmbedMasterBizStarted);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
     /**
      * 事件重复发送的场景
      */

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/test/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListenerTest.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/test/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListenerTest.java
@@ -21,6 +21,7 @@ import com.alipay.sofa.ark.support.startup.EmbedSofaArkBootstrap;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.ContextStartedEvent;

--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/test/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListenerTest.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/test/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListenerTest.java
@@ -76,7 +76,7 @@ public class ArkDeployStaticBizListenerTest {
     }
 
       /**
-     * applicationEvent 不是 spring 根上下文的场景
+     *  applicationEvent 不是 spring 根上下文的场景
      */
     @Test
     public void testNonSpringRootEvent() {


### PR DESCRIPTION

### 问题描述
解决使用静态部署方案启动基座时，如果基座依赖了OpenFeign，会在基座refresh [context期间触发ContextRefreshedEvent，导致模块被提前部署，基座启动失败

### 解决办法
静态部署时排除由 OpenFeign 触发的非spring根上下文发出的ContextRefreshedEvent事件


Fixes https://github.com/sofastack/sofa-ark/issues/1032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment now only triggers when the root application context is refreshed, preventing unintended deployments in child contexts.

- **Tests**
  - Added a test to ensure deployment does not occur for non-root application contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->