### PR TITLE
Feat slim plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </modules>
 
     <properties>
-        <sofa.ark.version>2.3.1</sofa.ark.version>
+        <sofa.ark.version>2.3.2-SNAPSHOT</sofa.ark.version>
         <sofa.ark.version.old>2.3.0</sofa.ark.version.old>
         <project.encoding>UTF-8</project.encoding>
         <java.version>1.8</java.version>

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/MavenUtils.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/MavenUtils.java
@@ -20,6 +20,7 @@ import com.alipay.sofa.ark.common.util.StringUtils;
 import com.alipay.sofa.ark.tools.ArtifactItem;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Parent;
 import org.apache.maven.project.MavenProject;
 
 import java.util.Arrays;
@@ -164,6 +165,19 @@ public class MavenUtils {
             return dependency.getGroupId() + STRING_COLON + dependency.getArtifactId()
                    + STRING_COLON + dependency.getType();
         }
+    }
+
+    public static String getGAIdentity(Artifact artifact) {
+        return artifact.getGroupId() + STRING_COLON + artifact.getArtifactId();
+    }
+
+    public static String getGAIdentity(Parent parent) {
+        return parent.getGroupId() + STRING_COLON + parent.getArtifactId();
+    }
+
+    public static String getGAVIdentity(Parent parent) {
+        return parent.getGroupId() + STRING_COLON + parent.getArtifactId() + STRING_COLON
+               + parent.getVersion();
     }
 
 }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimConfig.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimConfig.java
@@ -73,11 +73,6 @@ public class ModuleSlimConfig {
     private boolean               excludeWithIndirectDependencies                   = true;
 
     /**
-     * 在排除依赖时，是否根据基座依赖标识（baseDependencyParentIdentity）排除与基座相同的依赖（GAV 均相同）
-     */
-    private boolean               excludeSameBaseDependency                         = true;
-
-    /**
      * 在排除依赖时，如果排除的依赖与基座不一致，是否构建失败
      */
     private boolean               buildFailWhenExcludeBaseDependencyWithDiffVersion = false;
@@ -166,14 +161,6 @@ public class ModuleSlimConfig {
 
     public void setExcludeWithIndirectDependencies(boolean excludeWithIndirectDependencies) {
         this.excludeWithIndirectDependencies = excludeWithIndirectDependencies;
-    }
-
-    public boolean isExcludeSameBaseDependency() {
-        return excludeSameBaseDependency;
-    }
-
-    public void setExcludeSameBaseDependency(boolean excludeSameBaseDependency) {
-        this.excludeSameBaseDependency = excludeSameBaseDependency;
     }
 
     public boolean isBuildFailWhenExcludeBaseDependencyWithDiffVersion() {

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimExecutor.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimExecutor.java
@@ -298,11 +298,11 @@ public class ModuleSlimExecutor {
         Map<String, Object> arkYaml = ArkConfigHolder.getArkYaml(baseDir.getAbsolutePath());
         Properties prop = ArkConfigHolder.getArkProperties(baseDir.getAbsolutePath());
 
-        config.setExcludeWithIndirectDependencies(getBooleanWithDefault(prop,arkYaml,
+        config.setExcludeWithIndirectDependencies(getBooleanWithDefault(prop, arkYaml,
             EXTENSION_EXCLUDE_WITH_INDIRECT_DEPENDENCIES, true));
 
-        config.setBuildFailWhenExcludeBaseDependencyWithDiffVersion(getBooleanWithDefault(prop,arkYaml,
-            EXTENSION_BUILD_FAIL_WHEN_EXCLUDE_DIFF_BASE_DEPENDENCY, false));
+        config.setBuildFailWhenExcludeBaseDependencyWithDiffVersion(getBooleanWithDefault(prop,
+            arkYaml, EXTENSION_BUILD_FAIL_WHEN_EXCLUDE_DIFF_BASE_DEPENDENCY, false));
 
         initExcludeAndIncludeConfig();
     }

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimExecutor.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimExecutor.java
@@ -298,14 +298,10 @@ public class ModuleSlimExecutor {
         Map<String, Object> arkYaml = ArkConfigHolder.getArkYaml(baseDir.getAbsolutePath());
         Properties prop = ArkConfigHolder.getArkProperties(baseDir.getAbsolutePath());
 
-        config.setExcludeWithIndirectDependencies(getBooleanWithDefault(prop,
-            EXTENSION_EXCLUDE_WITH_INDIRECT_DEPENDENCIES, true));
-        config.setExcludeWithIndirectDependencies(getBooleanWithDefault(arkYaml,
+        config.setExcludeWithIndirectDependencies(getBooleanWithDefault(prop,arkYaml,
             EXTENSION_EXCLUDE_WITH_INDIRECT_DEPENDENCIES, true));
 
-        config.setBuildFailWhenExcludeBaseDependencyWithDiffVersion(getBooleanWithDefault(prop,
-            EXTENSION_BUILD_FAIL_WHEN_EXCLUDE_DIFF_BASE_DEPENDENCY, false));
-        config.setBuildFailWhenExcludeBaseDependencyWithDiffVersion(getBooleanWithDefault(arkYaml,
+        config.setBuildFailWhenExcludeBaseDependencyWithDiffVersion(getBooleanWithDefault(prop,arkYaml,
             EXTENSION_BUILD_FAIL_WHEN_EXCLUDE_DIFF_BASE_DEPENDENCY, false));
 
         initExcludeAndIncludeConfig();

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimExecutor.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimExecutor.java
@@ -127,7 +127,7 @@ public class ModuleSlimExecutor {
         return filteredArtifacts;
     }
 
-    private Model resolvePomAsOriginalModel(String groupId, String artifactId, String version) {
+    protected Model resolvePomAsOriginalModel(String groupId, String artifactId, String version) {
         try {
             Artifact artifact = repositorySystem
                 .createProjectArtifact(groupId, artifactId, version);
@@ -140,7 +140,7 @@ public class ModuleSlimExecutor {
         }
     }
 
-    private Set<Artifact> getArtifactsToFilterByBasePlugin(Set<Artifact> artifacts) {
+    protected Set<Artifact> getArtifactsToFilterByBasePlugin(Set<Artifact> artifacts) {
         if (!excludeWithBaseDependencyParentIdentity()) {
             return Collections.emptySet();
         }
@@ -158,7 +158,7 @@ public class ModuleSlimExecutor {
         return artifacts.stream().filter(it -> dependencyIdentities.contains(getArtifactIdentityWithoutVersion(it))).collect(Collectors.toSet());
     }
 
-    private List<Model> getBasePluginModel(){
+    protected List<Model> getBasePluginModel(){
         // 先通过 project.getOriginalModel().getDependencyManagement().getDependencies() 获取所有 type 为 pom 的 dependencies
         List<Dependency> pomDependenciesInDependencyManagement = Optional.ofNullable(project)
                 .map(MavenProject::getOriginalModel)

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
@@ -39,6 +39,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.plugins.dependency.tree.TreeMojo;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
@@ -95,6 +96,9 @@ public class RepackageMojo extends TreeMojo {
 
     @Component
     private RepositorySystem       repositorySystem;
+
+    @Component
+    private ProjectBuilder         projectBuilder;
 
     /**
      * Directory containing the generated archive
@@ -317,7 +321,7 @@ public class RepackageMojo extends TreeMojo {
     private File                   gitDirectory;
 
     /**
-     * 基座依赖标识，以 ${groupId}:${artifactId}:${version} 标识
+     * 基座依赖标识，以 ${groupId}:${artifactId}:${version} 标识，或以 ${groupId}:${artifactId} 标识
      */
     @Parameter(defaultValue = "")
     private String                 baseDependencyParentIdentity;
@@ -555,9 +559,10 @@ public class RepackageMojo extends TreeMojo {
             .setExcludes(excludes).setExcludeGroupIds(excludeGroupIds)
             .setExcludeArtifactIds(excludeArtifactIds)
             .setBaseDependencyParentIdentity(baseDependencyParentIdentity);
-        ModuleSlimStrategy slimStrategy = new ModuleSlimStrategy(this.mavenProject,
-            parseDependencyGraph(), moduleSlimConfig, this.baseDir, this.getLog());
-        return slimStrategy.getSlimmedArtifacts();
+        ModuleSlimExecutor slimStrategyExecutor = new ModuleSlimExecutor(this.mavenProject,
+            this.repositorySystem, projectBuilder, parseDependencyGraph(), moduleSlimConfig,
+            this.baseDir, this.getLog());
+        return slimStrategyExecutor.getSlimmedArtifacts();
     }
 
     private File getAppTargetFile() {

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/utils/ParseUtils.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/utils/ParseUtils.java
@@ -72,6 +72,17 @@ public class ParseUtils {
         return Boolean.parseBoolean(value.toString());
     }
 
+    public static boolean getBooleanWithDefault(Properties prop, Map<String, Object> yaml, String confKey,
+                                                boolean defaultValue) {
+        Object valueFromProp = prop.getProperty(confKey);
+        Object valueFromYaml = getValue(yaml, confKey);
+
+        if (null == valueFromProp && null == valueFromYaml) {
+            return defaultValue;
+        }
+        return null != valueFromProp? Boolean.parseBoolean(valueFromProp.toString()):Boolean.parseBoolean(valueFromYaml.toString());
+    }
+
     private static Object getValue(Map<String, Object> yaml, String confKey) {
         if (MapUtils.isEmpty(yaml) || StringUtils.isEmpty(confKey)) {
             return null;

--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/utils/ParseUtils.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/utils/ParseUtils.java
@@ -72,15 +72,16 @@ public class ParseUtils {
         return Boolean.parseBoolean(value.toString());
     }
 
-    public static boolean getBooleanWithDefault(Properties prop, Map<String, Object> yaml, String confKey,
-                                                boolean defaultValue) {
+    public static boolean getBooleanWithDefault(Properties prop, Map<String, Object> yaml,
+                                                String confKey, boolean defaultValue) {
         Object valueFromProp = prop.getProperty(confKey);
         Object valueFromYaml = getValue(yaml, confKey);
 
         if (null == valueFromProp && null == valueFromYaml) {
             return defaultValue;
         }
-        return null != valueFromProp? Boolean.parseBoolean(valueFromProp.toString()):Boolean.parseBoolean(valueFromYaml.toString());
+        return null != valueFromProp ? Boolean.parseBoolean(valueFromProp.toString()) : Boolean
+            .parseBoolean(valueFromYaml.toString());
     }
 
     private static Object getValue(Map<String, Object> yaml, String confKey) {

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimExecutorTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/ModuleSlimExecutorTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
  * @author lianglipeng.llp@alibaba-inc.com
  * @version $Id: ModuleSlimStrategyTest.java, v 0.1 2024年07月24日 16:33 立蓬 Exp $
  */
-public class ModuleSlimStrategyTest {
+public class ModuleSlimExecutorTest {
 
     @Test
     public void testGetSlimmedArtifacts() throws MojoExecutionException, IOException,
@@ -77,7 +77,7 @@ public class ModuleSlimStrategyTest {
         Set<Artifact> artifacts = Sets.newHashSet(a1, a2, a3);
         when(proj.getArtifacts()).thenReturn(artifacts);
 
-        ModuleSlimStrategy strategy = spy(new ModuleSlimStrategy(proj, null,
+        ModuleSlimExecutor strategy = spy(new ModuleSlimExecutor(proj, null,
             new ModuleSlimConfig(), mockBaseDir(), null));
 
         doNothing().when(strategy).checkExcludeByParentIdentity(anySet(), anySet());
@@ -102,7 +102,7 @@ public class ModuleSlimStrategyTest {
         ModuleSlimConfig moduleSlimConfig = new ModuleSlimConfig();
         moduleSlimConfig.setExcludes(Sets.newLinkedHashSet(Arrays.asList(".*")));
         moduleSlimConfig.setIncludes(Sets.newLinkedHashSet(Arrays.asList("*")));
-        ModuleSlimStrategy strategy = spy(new ModuleSlimStrategy(proj, null, moduleSlimConfig,
+        ModuleSlimExecutor strategy = spy(new ModuleSlimExecutor(proj, null, moduleSlimConfig,
             mockBaseDir(), null));
 
         doNothing().when(strategy).checkExcludeByParentIdentity(anySet(), anySet());
@@ -123,7 +123,7 @@ public class ModuleSlimStrategyTest {
                                                           MojoExecutionException {
         ModuleSlimConfig config = (new ModuleSlimConfig())
             .setBaseDependencyParentIdentity("com.mock:base-dependencies-starter:1.0");
-        ModuleSlimStrategy strategy = new ModuleSlimStrategy(getMockBootstrapProject(), null,
+        ModuleSlimExecutor strategy = new ModuleSlimExecutor(getMockBootstrapProject(), null,
             config, mockBaseDir(), null);
 
         Artifact sameArtifact = mock(Artifact.class);
@@ -164,7 +164,7 @@ public class ModuleSlimStrategyTest {
         doNothing().when(log).info(anyString());
         doNothing().when(log).error(anyString());
 
-        ModuleSlimStrategy strategy = new ModuleSlimStrategy(getMockBootstrapProject(), null,
+        ModuleSlimExecutor strategy = new ModuleSlimExecutor(getMockBootstrapProject(), null,
             config, mockBaseDir(), log);
 
         // 基座和模块都有该依赖，且版本一致
@@ -249,7 +249,7 @@ public class ModuleSlimStrategyTest {
         // find base-dependency-parent by gav identity
         ModuleSlimConfig config = (new ModuleSlimConfig())
             .setBaseDependencyParentIdentity("com.mock:base-dependencies-starter:1.0");
-        ModuleSlimStrategy strategy = new ModuleSlimStrategy(getMockBootstrapProject(), null,
+        ModuleSlimExecutor strategy = new ModuleSlimExecutor(getMockBootstrapProject(), null,
             config, mockBaseDir(), null);
         assertNotNull(strategy.getBaseDependencyParentOriginalModel());
 
@@ -262,7 +262,7 @@ public class ModuleSlimStrategyTest {
     public void testExtensionExcludeAndIncludeArtifactsByDefault() throws URISyntaxException,
                                                                   IOException {
         ModuleSlimConfig config = new ModuleSlimConfig();
-        ModuleSlimStrategy strategy = new ModuleSlimStrategy(getMockBootstrapProject(), null,
+        ModuleSlimExecutor strategy = new ModuleSlimExecutor(getMockBootstrapProject(), null,
             config, mockBaseDir(), mockLog());
 
         strategy.configExcludeArtifactsByDefault();
@@ -281,7 +281,7 @@ public class ModuleSlimStrategyTest {
     @Test
     public void testExtensionExcludeAndIncludeArtifacts() throws URISyntaxException {
         ModuleSlimConfig config = new ModuleSlimConfig();
-        ModuleSlimStrategy strategy = new ModuleSlimStrategy(null, null, config, mockBaseDir(),
+        ModuleSlimExecutor strategy = new ModuleSlimExecutor(null, null, config, mockBaseDir(),
             mockLog());
         URL resource = this.getClass().getClassLoader().getResource("excludes.txt");
         strategy.extensionExcludeAndIncludeArtifacts(resource.getPath());
@@ -307,7 +307,7 @@ public class ModuleSlimStrategyTest {
         artifacts.add(defaultArtifact1);
         artifacts.add(defaultArtifact2);
 
-        ModuleSlimStrategy strategy = new ModuleSlimStrategy(null, null, null, mockBaseDir(),
+        ModuleSlimExecutor strategy = new ModuleSlimExecutor(null, null, null, mockBaseDir(),
             mockLog());
         strategy.logExcludeMessage(jarGroupIds, jarArtifactIds, jarList, artifacts, true);
         strategy.logExcludeMessage(jarGroupIds, jarArtifactIds, jarList, artifacts, false);
@@ -327,7 +327,7 @@ public class ModuleSlimStrategyTest {
         // NOTE: Access httpbin to run unit test, need vpn maybe.
         String packExcludesUrl = "http://httpbin.org/get";
 
-        ModuleSlimStrategy strategy = new ModuleSlimStrategy(null, null, new ModuleSlimConfig(),
+        ModuleSlimExecutor strategy = new ModuleSlimExecutor(null, null, new ModuleSlimConfig(),
             mockBaseDir(), mockLog());
         strategy.extensionExcludeArtifactsFromUrl(packExcludesUrl, artifacts);
     }
@@ -361,7 +361,7 @@ public class ModuleSlimStrategyTest {
         artifact.setFile(new File("./"));
         artifacts.add(artifact);
 
-        ModuleSlimStrategy strategy = new ModuleSlimStrategy(null, null, null, mockBaseDir(),
+        ModuleSlimExecutor strategy = new ModuleSlimExecutor(null, null, null, mockBaseDir(),
             mockLog());
         strategy.logExcludeMessage(jarGroupIds, jarArtifactIds, jarList, artifacts, true);
         strategy.logExcludeMessage(jarGroupIds, jarArtifactIds, jarList, artifacts, false);
@@ -385,7 +385,7 @@ public class ModuleSlimStrategyTest {
             .singletonList("a3")));
         moduleSlimConfig.setExcludeWithIndirectDependencies(false);
 
-        ModuleSlimStrategy strategy = spy(new ModuleSlimStrategy(proj, null, moduleSlimConfig,
+        ModuleSlimExecutor strategy = spy(new ModuleSlimExecutor(proj, null, moduleSlimConfig,
             mockBaseDir(), null));
         Set<Artifact> res = strategy.getArtifactsToFilterByExcludeConfig(artifacts);
         assertEquals(3, res.size());
@@ -447,7 +447,7 @@ public class ModuleSlimStrategyTest {
         when(d4Node.getChildren()).thenReturn(Lists.newArrayList());
 
 
-        ModuleSlimStrategy strategy = spy(new ModuleSlimStrategy(proj, root, moduleSlimConfig,
+        ModuleSlimExecutor strategy = spy(new ModuleSlimExecutor(proj, root, moduleSlimConfig,
                 null, null));
         Set<Artifact> res = strategy.getArtifactsToFilterByExcludeConfig(artifacts);
         assertEquals(7, res.size());

--- a/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/test/java/com/alipay/sofa/ark/boot/mojo/RepackageMojoTest.java
@@ -16,8 +16,8 @@
  */
 package com.alipay.sofa.ark.boot.mojo;
 
-import com.alipay.sofa.ark.boot.mojo.ModuleSlimStrategy.ExcludeConfig;
-import com.alipay.sofa.ark.boot.mojo.ModuleSlimStrategy.ExcludeConfigResponse;
+import com.alipay.sofa.ark.boot.mojo.ModuleSlimExecutor.ExcludeConfig;
+import com.alipay.sofa.ark.boot.mojo.ModuleSlimExecutor.ExcludeConfigResponse;
 import com.alipay.sofa.ark.tools.ArtifactItem;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;


### PR DESCRIPTION
根据基座插件打出的 bom 瘦身及瘦身优化：
1. 瘦身优化：
a. 配置优化：如果模块配置的 parent 是基座 starter，且模块 sofa-ark-maven-plugin 中配置了 baseDependencyParentIdentity 标识，那么就会根据该 starter 做瘦身：将瘦身所有基座中有的依赖（GroupId 和 artifactId 相同即可）；
b. 日志优化：打印瘦身了但基座中没有的依赖；打印瘦身了但基座里不同版本的依赖。
c. 构建防御：如果配置了 buildFailWhenExcludeDiffBaseDependency = true 且瘦身了基座中没有或基座有不同版本的依赖，那么直接构建失败
2. 根据基座插件打出的 bom 瘦身：
当模块配置的 parent 是基座 starter、且模块 sofa-ark-maven-plugin 中配置了 baseDependencyParentIdentity 标识、且模块正在 dependencyManagement 中引入了基座插件打出的 plugin-bom （打 plugin-bom 的方式见 https://github.com/koupleless/runtime/pull/244 ），那么瘦身时，将一同瘦身该 bom 中 dependencyManagement 中声明的依赖。如：

```
    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>com.alipay.lipengtestsingle</groupId>
                <artifactId>lipengtestsingle-plugin-bom</artifactId>
                <version>0.0.1</version>
                <scope>import</scope>
                <type>pom</type>
            </dependency>
        </dependencies>
    </dependencyManagement>

```