### PR TITLE
静态合并部署重新启动问题

### DIFF
--- a/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
+++ b/sofa-ark-parent/support/ark-springboot-integration/ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/listener/ArkDeployStaticBizListener.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ArkDeployStaticBizListener implements ApplicationListener<ApplicationContextEvent>,
                                        Ordered {
 
-    private final AtomicBoolean deployed = new AtomicBoolean(false);
+    private static final AtomicBoolean deployed = new AtomicBoolean(false);
 
     @Override
     public void onApplicationEvent(ApplicationContextEvent event) {


### PR DESCRIPTION
 解决nacos更改logging.level.com配置后，触发 ContextRefreshedEvent 事件，导致静态合并部署重新启动问题

### Motivation

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification

Describe the idea and modifications you've done.

### Result

Resolved or fixed #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of deployment status to use a shared flag across all instances, with no change to visible functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->