### PR TITLE
fix: add bizName-level locking to prevent concurrent same-name biz installation npe

### DIFF
--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/model/BizModel.java
@@ -50,7 +50,6 @@ import java.io.StringWriter;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -59,6 +58,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.alipay.sofa.ark.spi.constant.Constants.BIZ_TEMP_WORK_DIR_RECYCLE_FILE_SUFFIX;
 import static com.alipay.sofa.ark.spi.constant.Constants.ACTIVATE_MULTI_BIZ_VERSION_ENABLE;
@@ -379,31 +379,40 @@ public class BizModel implements Biz {
 
         BizManagerService bizManagerService = ArkServiceContainerHolder.getContainer().getService(
             BizManagerService.class);
+        ReentrantLock bizLock = bizManagerService.getBizLock(bizName);
+        
+        // lock the bizName to ensure biz with same name install in sequence
+        bizLock.lock();
+        try {
 
-        // case0: active the first module as activated
-        if (bizManagerService.getActiveBiz(bizName) == null) {
-            setBizState(BizState.ACTIVATED, StateChangeReason.STARTED);
-            return;
-        }
+            // case0: active the first module as activated
+            if (bizManagerService.getActiveBiz(bizName) == null) {
+                setBizState(BizState.ACTIVATED, StateChangeReason.STARTED);
+                return;
+            }
 
-        // case1: support multiple version biz as activated: always activate the new version and keep the old module activated
-        boolean activateMultiBizVersion = Boolean.parseBoolean(ArkConfigs.getStringValue(
-            ACTIVATE_MULTI_BIZ_VERSION_ENABLE, "false"));
-        if (activateMultiBizVersion) {
-            setBizState(BizState.ACTIVATED, StateChangeReason.STARTED);
-            return;
-        }
+            // case1: support multiple version biz as activated: always activate the new version and keep the old module activated
+            boolean activateMultiBizVersion = Boolean.parseBoolean(ArkConfigs.getStringValue(
+                ACTIVATE_MULTI_BIZ_VERSION_ENABLE, "false"));
+            if (activateMultiBizVersion) {
+                setBizState(BizState.ACTIVATED, StateChangeReason.STARTED);
+                return;
+            }
 
-        // case2: always activate the new version and deactivate the old module according to ACTIVATE_NEW_MODULE config
-        if (Boolean.getBoolean(Constants.ACTIVATE_NEW_MODULE)) {
-            Biz currentActiveBiz = bizManagerService.getActiveBiz(bizName);
-            ((BizModel) currentActiveBiz).setBizState(BizState.DEACTIVATED,
-                StateChangeReason.SWITCHED, String.format("switch to new biz %s", getIdentity()));
-            setBizState(BizState.ACTIVATED, StateChangeReason.STARTED,
-                String.format("switch from old biz: %s", currentActiveBiz.getIdentity()));
-        } else {
-            // case3: always deactivate the new version and keep old module activated according to ACTIVATE_NEW_MODULE config
-            setBizState(BizState.DEACTIVATED, StateChangeReason.STARTED, "start but is deactivated");
+            // case2: always activate the new version and deactivate the old module according to ACTIVATE_NEW_MODULE config
+            if (Boolean.getBoolean(Constants.ACTIVATE_NEW_MODULE)) {
+                Biz currentActiveBiz = bizManagerService.getActiveBiz(bizName);
+                ((BizModel) currentActiveBiz).setBizState(BizState.DEACTIVATED,
+                    StateChangeReason.SWITCHED, String.format("switch to new biz %s", getIdentity()));
+                setBizState(BizState.ACTIVATED, StateChangeReason.STARTED,
+                    String.format("switch from old biz: %s", currentActiveBiz.getIdentity()));
+            } else {
+                // case3: always deactivate the new version and keep old module activated according to ACTIVATE_NEW_MODULE config
+                setBizState(BizState.DEACTIVATED, StateChangeReason.STARTED, "start but is deactivated");
+            }
+        } finally {
+            // ensure the lock will be released, avoid deadlock
+            bizLock.unlock();
         }
     }
 

--- a/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/biz/BizManagerServiceImpl.java
+++ b/sofa-ark-parent/core-impl/container/src/main/java/com/alipay/sofa/ark/container/service/biz/BizManagerServiceImpl.java
@@ -30,6 +30,7 @@ import com.google.inject.Singleton;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  *  Service Implementation to manager ark biz
@@ -41,6 +42,15 @@ import java.util.concurrent.ConcurrentHashMap;
 public class BizManagerServiceImpl implements BizManagerService {
 
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, Biz>> bizRegistration = new ConcurrentHashMap<>();
+    
+    private final ConcurrentHashMap<String, ReentrantLock> bizLocks = new ConcurrentHashMap<>();
+
+    @Override
+    public ReentrantLock getBizLock(String bizName) {
+        AssertUtils.isFalse(StringUtils.isEmpty(bizName), "Biz name must not be empty.");
+        bizLocks.putIfAbsent(bizName, new ReentrantLock());
+        return bizLocks.get(bizName);
+    }
 
     @Override
     public boolean registerBiz(Biz biz) {

--- a/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/service/biz/BizManagerService.java
+++ b/sofa-ark-parent/core/spi/src/main/java/com/alipay/sofa/ark/spi/service/biz/BizManagerService.java
@@ -22,6 +22,7 @@ import com.alipay.sofa.ark.spi.model.BizState;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Service to manage biz
@@ -157,4 +158,10 @@ public interface BizManagerService {
 
     ConcurrentHashMap<String, ConcurrentHashMap<String, Biz>> getBizRegistration();
 
+    /**
+     * get the lock for the biz with the given name
+     * @param bizName
+     * @return
+     */
+    ReentrantLock getBizLock(String bizName);
 }


### PR DESCRIPTION
- Add ReentrantLock management in BizManagerServiceImpl
- Implement lock mechanism in BizModel.doStart() with try-finally

### Motivation

All threads may find getActiveBiz(bizName) returning null at the same time, causing multiple biz modules with the same name to be activated simultaneously. This leads to inconsistent state management and violates the expected behavior where only one biz module of a given name should be active at a time.

### Modification
To fix this race condition, I implemented a bizName-level locking mechanism:

Added lock management in BizManagerServiceImpl:

- Added ConcurrentHashMap<String, ReentrantLock> bizLocks to store locks for each bizName

- Implemented getBizLock(String bizName) method to provide thread-safe lock acquisition

- Modified BizModel.doStart() method:

- Added lock acquisition before the biz activation logic

- Wrapped the entire activation logic in a try-finally block

- Ensured proper lock release in the finally block to prevent deadlocks

### Result

This fix ensures that biz modules with the same name are installed sequentially rather than concurrently, preventing the race condition where multiple modules could be activated simultaneously. The locking mechanism is efficient and only affects modules with the same name, allowing different biz modules to install concurrently without performance impact.
The solution maintains backward compatibility and follows existing code patterns while providing a robust fix for the concurrent installation issue.
