### PR TITLE
--bugfix=springboot打包嵌套jar方式路径识别改为/！

### DIFF
--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/bootstrap/ClasspathLauncher.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/bootstrap/ClasspathLauncher.java
@@ -47,7 +47,7 @@ public class ClasspathLauncher extends ArkLauncher {
 
     public static class ClassPathArchive implements ExecutableArchive {
 
-        public static final String     FILE_IN_JAR = "!/";
+        public static final String     FILE_IN_JAR = "/!";
 
         private final String           className;
 


### PR DESCRIPTION
Image
发现是框架中的代码抛出的的错误，idea启动没问题 java -jar 启动报错

深入阅读源码后发现并猜测的问题原因

spring生成的jar包结构是
wm-web-svr-6.16.0-SNAPSHOT-ark-biz.jar/!BOOT-INF/lib/sofa-ark-all-3.1.10.jar 注意/！

但是在ark框架源码中识别的是 !/

Image Image
正常逻辑嵌套jar包应该明宗if的判断条件，但是显然是没有命中的

依赖pom改动

Image Image
打包插件

Image
按照官方文档就只改动了这些
我是按照官方文档一步一步来的
https://www.sofastack.tech/projects/sofa-boot/sofa-ark-spring-boot-demo/

SOFAArk version: 3.1.10
JVM version (e.g. java -version): jdk21
OS version (e.g. uname -a):
Maven version: 3.9.5
IDE version: