### PR TITLE
fix(maven-plugin): escape userProperties using double quotes

### DIFF
--- a/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
+++ b/sofa-ark-parent/support/ark-maven-plugin/src/main/java/com/alipay/sofa/ark/boot/mojo/RepackageMojo.java
@@ -484,7 +484,7 @@ public class RepackageMojo extends TreeMojo {
                 if (key instanceof String && StringUtils.equals("outputFile", (String) key)) {
                     return;
                 }
-                goals.add(String.format("-D%s=%s", key, value));
+                goals.add(String.format("-D%s=%s", key, "\"" + value + "\""));
             });
         }
 


### PR DESCRIPTION
### Motivation

Fix sofa-ark-maven-plugin repackage blank space handling

### Result

Resolved or fixed #1095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved command generation for dependency analysis to correctly quote user-defined properties. Values containing spaces or special characters are now preserved, preventing failures or misinterpretation during execution. This ensures more reliable behavior when passing custom properties via command-line flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->