### PR TITLE
fix(loader): close all pooled RandomAccessFiles in FilePool.close

### DIFF
--- a/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/data/RandomAccessDataFile.java
+++ b/sofa-ark-parent/core-impl/archive/src/main/java/com/alipay/sofa/ark/loader/data/RandomAccessDataFile.java
@@ -258,14 +258,26 @@ public class RandomAccessDataFile implements RandomAccessData {
 
         public void close() throws IOException {
             this.available.acquireUninterruptibly(this.size);
+            IOException first = null;
             try {
                 RandomAccessFile pooledFile = this.files.poll();
                 while (pooledFile != null) {
-                    pooledFile.close();
+                    try {
+                        pooledFile.close();
+                    } catch (IOException e) {
+                        if (first == null) {
+                            first = e;
+                        } else {
+                            first.addSuppressed(e);
+                        }
+                    }
                     pooledFile = this.files.poll();
                 }
             } finally {
                 this.available.release(this.size);
+            }
+            if (first != null) {
+                throw first;
             }
         }
 


### PR DESCRIPTION
### Motivation

`FilePool.close()` closes pooled `RandomAccessFile` instances in a loop. If one `close()` throws an `IOException`, the method exits early and the remaining pooled files are never closed, which can leak file descriptors and keep files locked.

### Modification

Make `FilePool.close()` exception-safe by wrapping each `RandomAccessFile.close()` in a try/catch, continuing to close remaining pooled files after a failure, and rethrowing the first `IOException` with subsequent failures added as suppressed exceptions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling and resource cleanup to ensure all pooled file resources are properly released during shutdown, even when multiple errors occur. Enhanced reliability of resource management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->